### PR TITLE
Refactor and shared reactivity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"@sveltejs/adapter-static": "^3.0.5",
 				"@sveltejs/kit": "^2.5.28",
 				"@types/cookie": "^0.6.0",
+				"@types/d3-delaunay": "^6.0.4",
 				"@types/jsonwebtoken": "^9.0.7",
 				"carbon-components-svelte": "^0.85.2",
 				"carbon-icons-svelte": "^12.11.0",
@@ -2918,6 +2919,13 @@
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
 			"dev": true
+		},
+		"node_modules/@types/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/d3-voronoi": {
 			"version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"@sveltejs/adapter-static": "^3.0.5",
 		"@sveltejs/kit": "^2.5.28",
 		"@types/cookie": "^0.6.0",
+		"@types/d3-delaunay": "^6.0.4",
 		"@types/jsonwebtoken": "^9.0.7",
 		"carbon-components-svelte": "^0.85.2",
 		"carbon-icons-svelte": "^12.11.0",

--- a/src/lib/components/map-cesium/LayerControlFlood/LayerControlFlood.svelte
+++ b/src/lib/components/map-cesium/LayerControlFlood/LayerControlFlood.svelte
@@ -1,38 +1,26 @@
 <script lang="ts">
-	import { get, writable, type Writable } from "svelte/store";
+	import { onDestroy } from "svelte";
 	import { _ } from "svelte-i18n";
-	import * as Cesium from "cesium";
 	import { Button, Loading, Slider, Toggle } from "carbon-components-svelte";
 	import { ArrowLeft, ArrowRight, Pause, Play } from "carbon-icons-svelte";
 
 	import type { Map } from "../module/map";
 	import ErrorMessage from "$lib/components/ui/components/ErrorMessage/ErrorMessage.svelte";
-	import { MapMeasurementFloodDepth } from "./map-measurement-flood-depth";
 	import { FloodLayerController } from "../MapToolFlooding/layer-controller";
-	import { onDestroy } from "svelte";
+	import { DepthGauge } from "./depth-gauge";
 
 	
 	export let floodLayerController: FloodLayerController;
 	export let map: Map;
 	export let showGlobeOpacitySlider: boolean = true;
 	
+	const globeOpacity = map.options.globeOpacity;
+
 	const { time, minTime, maxTime, speed, opacity } = floodLayerController;
 	const error = floodLayerController.floodLayer.error;
 	const floodLayerLoaded = floodLayerController.floodLayer.loaded;
 
 	let playing: boolean = false;
-
-	let previouseAnimateState: boolean
-
-	const enableMeasurement = writable<boolean>(false);
-	let measurementId: number = 0;
-	let measurements: Writable<Array<MapMeasurementFloodDepth>> = writable<Array<MapMeasurementFloodDepth>>(
-		new Array<MapMeasurementFloodDepth>()
-	);
-	let movingPoint: Cesium.Entity | undefined;
-	
-	const globeOpacity = map.options.globeOpacity;
-
 	let intervalId: NodeJS.Timeout | null;
 	function togglePlay(): void {
 		playing = !playing;
@@ -59,104 +47,19 @@
 		}
 	}
 
+	const depthGauge = new DepthGauge(map);
+	let depthGaugeEnabled = false;
+
+	$: depthGaugeEnabled ? depthGauge.activate() : depthGauge.deactivate();
+	
 	onDestroy(() => {
 		stopPlaying();
-	});
-
-	let leftClickHandle = (m: any) => {
-		createFloodMeasurement(getCartesian2(m));
-	};
-
-	let moveHandle = (m: any) => {
-		const picked = map.viewer.scene.pick(m);
-		if (picked?.primitive?.type === "flood") {
-			drawPointMove(getCartesian2(m));
-		} else if (movingPoint != undefined) {
-			removeMovingPoint();
-		}
-	};
-
-
-	function getCartesian2(m: any): Cesium.Cartesian2 {
-		return new Cesium.Cartesian2(m.x, m.y);
-	}
-
-	function removeMovingPoint(): void {
-		if (!movingPoint) return;
-
-		map.viewer.entities.remove(movingPoint);
-		movingPoint = undefined;
-	}
-
-	function addMovingPoint(position: Cesium.Cartesian3): void {
-		movingPoint = map.viewer.entities.add({
-			position: position,
-			point: {
-				show: true,
-				color: Cesium.Color.BLUE,
-				pixelSize: 10,
-				outlineColor: Cesium.Color.BLACK,
-				outlineWidth: 1
-			}
-		});
-	}
-
-	function createFloodMeasurement(location: Cesium.Cartesian2): void {
-		const picked = map.viewer.scene.pickPosition(location);
-		const measurement = addMeasurement();
-		measurement.addPoint(picked);
-
-		// add point on terrain
-		let pickedCartographic = Cesium.Cartographic.fromCartesian(picked);
-		Cesium.sampleTerrainMostDetailed(map.viewer.terrainProvider, [pickedCartographic]).then((result) => {
-			measurement.addPoint(Cesium.Cartographic.toCartesian(result[0]));
-		});
-	}
-
-	function drawPointMove(location: Cesium.Cartesian2): void {
-		const picked = map.viewer.scene.pickPosition(location);
-		if (!movingPoint) addMovingPoint(picked);
-		// @ts-ignore
-		movingPoint.position = new Cesium.ConstantPositionProperty(picked);
-	}
-
-	function addMeasurement(): MapMeasurementFloodDepth {
-		const newMeasurement = new MapMeasurementFloodDepth(measurementId, map);
-		$measurements.push(newMeasurement);
-		measurements.set($measurements);
-		measurementId++;
-		return newMeasurement;
-	}
-
-	function activate(): void {
-		map.on("mouseLeftClick", leftClickHandle);
-		map.on("mouseMove", moveHandle);
-		previouseAnimateState = get(map.options.animate);
-		map.options.animate.set(true);
-	}
-
-	function deactivate() {
-		map.off("mouseLeftClick", leftClickHandle);
-		map.off("mouseMove", moveHandle);
-		// remove all measurements
-		$measurements.forEach((measurement) => {
-			measurement?.remove();
-		});
-		removeMovingPoint();
-		map.options.animate.set(previouseAnimateState);
-
-		map.refresh();
-	}
-
-	enableMeasurement.subscribe((enable) => {
-		if (!enable) {
-			deactivate();
-		} else {
-			activate();
-		}
+		depthGauge.deactivate();
 	});
 
 </script>
+
+
 {#if !$floodLayerLoaded}
 	<div class="loading-wrapper">
 		<Loading withOverlay={false} small />
@@ -243,11 +146,8 @@
 		<div class="measure-checkbox">
 			<span class="label-02">{$_("tools.flooding.measureDepth")}</span>
 			<Toggle
-				toggled={$enableMeasurement}
+				bind:toggled={depthGaugeEnabled}
 				hideLabel={true}
-				on:toggle={() => {
-					$enableMeasurement = !$enableMeasurement;
-				}}
 				labelA={$_("general.off")}
 				labelB={$_("general.on")}
 			/>
@@ -255,7 +155,9 @@
 	</div>
 {/if}
 
+
 <style>
+
 	.loading-wrapper {
 		display: flex;
 		justify-content: center;

--- a/src/lib/components/map-cesium/LayerControlFlood/LayerControlFlood.svelte
+++ b/src/lib/components/map-cesium/LayerControlFlood/LayerControlFlood.svelte
@@ -1,117 +1,67 @@
 <script lang="ts">
-	import { Button, Dropdown, Loading, Slider, Toggle } from "carbon-components-svelte";
+	import { get, writable, type Writable } from "svelte/store";
+	import { _ } from "svelte-i18n";
 	import * as Cesium from "cesium";
+	import { Button, Loading, Slider, Toggle } from "carbon-components-svelte";
+	import { ArrowLeft, ArrowRight, Pause, Play } from "carbon-icons-svelte";
+
+	import type { Map } from "../module/map";
+	import ErrorMessage from "$lib/components/ui/components/ErrorMessage/ErrorMessage.svelte";
+	import { MapMeasurementFloodDepth } from "./map-measurement-flood-depth";
+	import { FloodLayerController } from "../MapToolFlooding/layer-controller";
 	import { onDestroy } from "svelte";
 
-	import type { FloodLayer } from "../module/layers/flood-layer";
-	import { _ } from "svelte-i18n";
-	import { get, writable, type Writable } from "svelte/store";
-	import { ArrowLeft, ArrowRight, Pause, Play } from "carbon-icons-svelte";
-	import type { Map } from "../module/map";
-	import { MapMeasurementFloodDepth } from "./map-measurement-flood-depth";
-	import ErrorMessage from "$lib/components/ui/components/ErrorMessage/ErrorMessage.svelte";
-	import { OgcFeaturesLayer } from "../module/layers/ogc-features-layer";
-	import { LayerConfig } from "$lib/components/map-core/layer-config";
-	// import addFloodedRoadsLayer from "$lib/components/map-cesium/MapToolFlooding/MapToolFlooding.svelte";
-
 	
-	export let layer: FloodLayer;
+	export let floodLayerController: FloodLayerController;
 	export let map: Map;
 	export let showGlobeOpacitySlider: boolean = true;
 	
-	let { timeSliderValue, timeSliderMin, timeSliderMax, timeSliderStep, opacity, loaded, error } = layer;
-	
+	const { time, minTime, maxTime, speed, opacity } = floodLayerController;
+	const error = floodLayerController.floodLayer.error;
+	const floodLayerLoaded = floodLayerController.floodLayer.loaded;
 
 	let playing: boolean = false;
-	let intervalId: NodeJS.Timeout
 
 	let previouseAnimateState: boolean
 
-	let enableMeasurement = writable<boolean>(false);
+	const enableMeasurement = writable<boolean>(false);
 	let measurementId: number = 0;
 	let measurements: Writable<Array<MapMeasurementFloodDepth>> = writable<Array<MapMeasurementFloodDepth>>(
 		new Array<MapMeasurementFloodDepth>()
 	);
 	let movingPoint: Cesium.Entity | undefined;
 	
-	let roadsLayer: OgcFeaturesLayer | undefined;
+	const globeOpacity = map.options.globeOpacity;
 
-	$: globeOpacity = map.options.globeOpacity;
-	
-	function addFloodedRoadsLayer(timestep: number) {
-        if (roadsLayer) {
-            map.removeLayer(roadsLayer);
-        }
-
-        const layerConfig = new LayerConfig({
-            id: "flooded_roads",
-            title: "Wegen",
-            type: "ogc-features",
-            settings: {
-                url: `http://localhost:5000`,
-                options: {
-                    collectionId: "nwb_floods",
-                    heightStartLoading: 50000,
-                    maxFeatures: 100000,
-                    tileWidth: 40640
-                },
-                parameters: {
-                    scenario: "26_NzSch-dp_160_300",
-                    timestep: (timestep * 6).toString(),
-                    limit: "1420"
-                }
-            },
-            isBackground: false,
-            defaultOn: true,
-            defaultAddToManager: false
-        });
-
-        roadsLayer = new OgcFeaturesLayer(map, layerConfig);
-        roadsLayer.addToMap();
-    
-		console.log("Changed roadsLayer from $timeSliderValue")
-	}
-
-	$: {
-        if ($timeSliderValue !== undefined) {
-            addFloodedRoadsLayer($timeSliderValue);
-        }
-    }
-	onDestroy(() => {
-        if (roadsLayer) {
-            map.removeLayer(roadsLayer);
-        }
-    });
-	// This doesn't work without a "$:" prefix, which causes each step to add additional subscriptions so I added a manual change
-	// layer.timeSliderValue.subscribe((value) => {
-	// 	if (value !== $timeSliderValue) {
-	// 		$timeSliderValue = value;
-	// 	}
-	// 	console.log($timeSliderValue, timeSliderValue)
-	// });
-
-
-	function togglePlay() {
+	let intervalId: NodeJS.Timeout | null;
+	function togglePlay(): void {
 		playing = !playing;
 		if (playing) {
 			intervalId = setInterval(() => {
-				layer.timeSliderValue.update((value) => {
-				if (value >= $timeSliderMax) {
-					playing = false;
-					clearInterval(intervalId);
-					return $timeSliderMin;
-				}
-				$timeSliderValue = value + $timeSliderStep;
-				return value + $timeSliderStep;
+				time.update((value) => {
+					if (value >= $maxTime) {
+						stopPlaying();
+						return value;
+					}
+					return value + $speed;
 				});
-			}, 1000);
+			}, 50);
 		} else {
-			if (intervalId !== null) {
-				clearInterval(intervalId);
-				intervalId = null;
-			}
+			stopPlaying();
 		}
   	}
+
+	function stopPlaying(): void {
+		playing = false;
+		if (intervalId !== null) {
+			clearInterval(intervalId);
+			intervalId = null;
+		}
+	}
+
+	onDestroy(() => {
+		stopPlaying();
+	});
 
 	let leftClickHandle = (m: any) => {
 		createFloodMeasurement(getCartesian2(m));
@@ -131,14 +81,14 @@
 		return new Cesium.Cartesian2(m.x, m.y);
 	}
 
-	function removeMovingPoint() {
+	function removeMovingPoint(): void {
 		if (!movingPoint) return;
 
 		map.viewer.entities.remove(movingPoint);
 		movingPoint = undefined;
 	}
 
-	function addMovingPoint(position: Cesium.Cartesian3) {
+	function addMovingPoint(position: Cesium.Cartesian3): void {
 		movingPoint = map.viewer.entities.add({
 			position: position,
 			point: {
@@ -151,7 +101,7 @@
 		});
 	}
 
-	function createFloodMeasurement(location: Cesium.Cartesian2) {
+	function createFloodMeasurement(location: Cesium.Cartesian2): void {
 		const picked = map.viewer.scene.pickPosition(location);
 		const measurement = addMeasurement();
 		measurement.addPoint(picked);
@@ -163,14 +113,14 @@
 		});
 	}
 
-	function drawPointMove(location: Cesium.Cartesian2) {
+	function drawPointMove(location: Cesium.Cartesian2): void {
 		const picked = map.viewer.scene.pickPosition(location);
 		if (!movingPoint) addMovingPoint(picked);
 		// @ts-ignore
 		movingPoint.position = new Cesium.ConstantPositionProperty(picked);
 	}
 
-	function addMeasurement() {
+	function addMeasurement(): MapMeasurementFloodDepth {
 		const newMeasurement = new MapMeasurementFloodDepth(measurementId, map);
 		$measurements.push(newMeasurement);
 		measurements.set($measurements);
@@ -178,7 +128,7 @@
 		return newMeasurement;
 	}
 
-	function activate() {
+	function activate(): void {
 		map.on("mouseLeftClick", leftClickHandle);
 		map.on("mouseMove", moveHandle);
 		previouseAnimateState = get(map.options.animate);
@@ -207,7 +157,7 @@
 	});
 
 </script>
-{#if !$loaded}
+{#if !$floodLayerLoaded}
 	<div class="loading-wrapper">
 		<Loading withOverlay={false} small />
 	</div>
@@ -231,12 +181,9 @@
 		</div>
 		<div class="wrapper">
 			<Slider 
-				value={$opacity}
+				bind:value={$opacity}
 				labelText={$_('tools.flooding.waterTransparency') + ' ' + $opacity + '%'} 
 				fullWidth={true} 
-				on:input={(e) => {
-					layer.opacity.set(e.detail);
-				}}
 				hideTextInput={true} 
 				min={0} 
 				max={100} 
@@ -248,18 +195,15 @@
 		<div class="label-01">Time slider</div>
 		<div class="wrapper">
 			<Slider 
-				bind:value={$timeSliderValue}
-				labelText={String($timeSliderValue) + " uur sinds bres"} 
-				fullWidth={true} 
-				on:input={(e) => {
-					layer.timeSliderValue.set(e.detail);
-				}}
-				hideTextInput={true} 
-				min={$timeSliderMin} 
-				max={$timeSliderMax} 
-				step={$timeSliderStep} 
-				minLabel={String($timeSliderMin)} 
-				maxLabel={String($timeSliderMax)}
+				bind:value={$time}
+				labelText={`${Math.round($time)} uur sinds bres`}
+				fullWidth={true}
+				hideTextInput={true}
+				min={$minTime}
+				max={$maxTime}
+				step={$speed}
+				minLabel={$minTime.toString()}
+				maxLabel={$maxTime.toString()}
 			/>
 		</div>
 		<div class="wrapper" style="display: flex; justify-content: center; gap: 4px;">
@@ -271,32 +215,18 @@
 				iconDescription={$_('tools.animation.previous')}
 				on:click={() => {
 					// After switching scenario or breach, the Slider no longer listens to layer.timeSliderValue, so #timeSliderValue must be updated manually
-					layer.timeSliderValue.update((value) => {$timeSliderValue -= 1; return value - $timeSliderStep});	
-					// layer.timeSliderValue.update((value) => value - $timeSliderStep);	
+					time.update((value) => value - $speed);	
 				}}
 			/>
-			{#if !playing}
-				<Button 
-					kind="secondary"
-					size="small" 
-					icon="{Play}"
-					iconDescription={$_('tools.animation.play')}
-					on:click={() => {
-						togglePlay();
-					}}
-				/>
-			{:else}
-				<Button 
-					kind="secondary"
-					size="small" 
-					icon="{Pause}"
-					iconDescription={$_('tools.animation.pause')}
-					on:click={() => {
-						togglePlay();
-					}}
-				/>	
-			{/if}
-			<!-- Increase time slider value by step -->
+			<Button 
+				kind="secondary"
+				size="small" 
+				icon={playing ? Pause : Play}
+				iconDescription={playing ? $_('tools.animation.pause') : $_('tools.animation.play')}
+				on:click={() => {
+					togglePlay();
+				}}
+			/>
 			<Button 
 				kind="secondary"
 				size="small" 
@@ -304,8 +234,7 @@
 				iconDescription={$_('tools.animation.next')}
 				on:click={() => {
 					// After switching scenario or breach, the Slider no longer listens to layer.timeSliderValue, so #timeSliderValue must be updated manually
-					layer.timeSliderValue.update((value) => {$timeSliderValue += 1; return value + $timeSliderStep});
-					// layer.timeSliderValue.update((value) => value + $timeSliderStep);	
+					time.update((value) => value + $speed);	
 				}}
 			/>
 		</div>

--- a/src/lib/components/map-cesium/LayerControlFlood/depth-gauge.ts
+++ b/src/lib/components/map-cesium/LayerControlFlood/depth-gauge.ts
@@ -1,0 +1,101 @@
+import { get, writable, type Writable } from "svelte/store";
+import * as Cesium from "cesium";
+import type { Map } from "../module/map";
+import { MapMeasurementFloodDepth } from "./map-measurement-flood-depth";
+
+
+export class DepthGauge {
+
+	private map: Map;
+	private measurements: Array<MapMeasurementFloodDepth> = [];
+	private measurementId: number;
+	private movingPoint: Cesium.Entity | undefined;
+	private previouseAnimateState: boolean = false;
+
+	private leftClickHandle = (m: any) => {
+		this.createFloodMeasurement(this.getCartesian2(m));
+	}
+
+	private moveHandle = (m: any) => {
+		const picked = this.map.viewer.scene.pick(m);
+		if (picked?.primitive?.type === "flood") {
+			this.drawPointMove(this.getCartesian2(m));
+		} else if (this.movingPoint != undefined) {
+			this.removeMovingPoint();
+		}
+	}
+
+	constructor(map: Map) {
+		this.map = map;
+		this.measurementId = 0;
+	}
+
+	private getCartesian2(m: any): Cesium.Cartesian2 {
+		return new Cesium.Cartesian2(m.x, m.y);
+	}
+
+	private removeMovingPoint(): void {
+		if (!this.movingPoint) return;
+		this.map.viewer.entities.remove(this.movingPoint);
+		this.movingPoint = undefined;
+	}
+
+	private addMovingPoint(position: Cesium.Cartesian3): void {
+		this.movingPoint = this.map.viewer.entities.add({
+			position: position,
+			point: {
+				show: true,
+				color: Cesium.Color.BLUE,
+				pixelSize: 10,
+				outlineColor: Cesium.Color.BLACK,
+				outlineWidth: 1
+			}
+		});
+	}
+
+	private drawPointMove(location: Cesium.Cartesian2): void {
+		const picked = this.map.viewer.scene.pickPosition(location);
+		if (!this.movingPoint) this.addMovingPoint(picked);
+		if (this.movingPoint) this.movingPoint.position = new Cesium.ConstantPositionProperty(picked);
+	}
+
+	private createFloodMeasurement(location: Cesium.Cartesian2): void {
+		const picked = this.map.viewer.scene.pickPosition(location);
+		const measurement = this.addMeasurement();
+		measurement.addPoint(picked);
+
+		// Add point on terrain
+		let pickedCartographic = Cesium.Cartographic.fromCartesian(picked);
+		Cesium.sampleTerrainMostDetailed(this.map.viewer.terrainProvider, [pickedCartographic]).then((result) => {
+			measurement.addPoint(Cesium.Cartographic.toCartesian(result[0]));
+		});
+	}
+
+	private addMeasurement(): MapMeasurementFloodDepth {
+		const newMeasurement = new MapMeasurementFloodDepth(this.measurementId, this.map);
+		this.measurements.push(newMeasurement);
+		this.measurementId++;
+		return newMeasurement;
+	}
+
+	public activate(): void {
+		this.map.on("mouseLeftClick", this.leftClickHandle);
+		this.map.on("mouseMove", this.moveHandle);
+		this.previouseAnimateState = get(this.map.options.animate);
+		this.map.options.animate.set(true);
+	}
+
+	public deactivate() {
+		this.map.off("mouseLeftClick", this.leftClickHandle);
+		this.map.off("mouseMove", this.moveHandle);
+		// remove all measurements
+		this.measurements.forEach((measurement) => {
+			measurement?.remove();
+		});
+		this.removeMovingPoint();
+		this.map.options.animate.set(this.previouseAnimateState);
+
+		this.map.refresh();
+	}
+	
+}

--- a/src/lib/components/map-cesium/LayerControlFlood/map-measurement-flood-depth.ts
+++ b/src/lib/components/map-cesium/LayerControlFlood/map-measurement-flood-depth.ts
@@ -1,21 +1,20 @@
 import * as Cesium from "cesium";
-
 import type { Map } from "../module/map";
 import { MapMeasurement } from "../module/map-measurement";
 
+
 export class MapMeasurementFloodDepth extends MapMeasurement {
 
-    constructor(id: number, map: Map) {
-        super(id, map);
+	constructor(id: number, map: Map) {
+		super(id, map);
 
-        this.helpLineColor = Cesium.Color.AQUA;
-        this.pointFill = Cesium.Color.BLUE;
-        this.lineColor = Cesium.Color.BLUE;
-        
-    }
+		this.helpLineColor = Cesium.Color.AQUA;
+		this.pointFill = Cesium.Color.BLUE;
+		this.lineColor = Cesium.Color.BLUE;
+	}
 
-    addPointEntity(location: Cesium.Cartesian3, index: number): void {
-        const entity = this.map.viewer.entities.add({
+	addPointEntity(location: Cesium.Cartesian3, index: number): void {
+		const entity = this.map.viewer.entities.add({
 			position: location,
 			point: {
 				show: true,
@@ -25,9 +24,7 @@ export class MapMeasurementFloodDepth extends MapMeasurement {
 				outlineWidth: 1
 			}
 		});
-
-        this.pointEntities.push(entity);
-        
-    }
+		this.pointEntities.push(entity);    
+	}
 
 }

--- a/src/lib/components/map-cesium/MapToolFlooding/BreachEntry.svelte
+++ b/src/lib/components/map-cesium/MapToolFlooding/BreachEntry.svelte
@@ -1,27 +1,26 @@
 <script lang="ts">
 	import type { Writable } from "svelte/store";
 	import { _ } from "svelte-i18n";
-	import { Location, Close } from "carbon-icons-svelte";
-	import type { CesiumIcon } from "../module/cesium-icon";
-	import { Button, Tooltip } from "carbon-components-svelte";
+	import { Close } from "carbon-icons-svelte";
+	import { Button } from "carbon-components-svelte";
+	import type { Breach } from "./layer-controller";
 
-
-	export let breach: CesiumIcon;
-	export let active: Writable<CesiumIcon | undefined>;
-	export let hovered: Writable<CesiumIcon | undefined>;
+	export let breach: Breach;
+	export let active: Writable<Breach | undefined>;
+	export let hovered: Writable<Breach | undefined>;
 		
 	export let showInfo: boolean = true;
 
+	const name = breach.properties.name;
+	const dijkring = breach.properties.dijkring;
+
+	$: hoveredBoolean = $hovered === breach;
+	$: activeBoolean = $active === breach;
 
 	function entryClick(): void {
 		if (breach !== $active) active.set(breach);
 		showInfo = true;
 	}
-
-	$: hoveredBoolean = $hovered === breach;
-	$: activeBoolean = $active === breach;
-	$: name = breach.properties.name;
-	$: dijkring = breach.properties.dijkring;
 
 </script>
 
@@ -32,11 +31,11 @@
 	<div class="entry" on:click={entryClick} class:entry-hovered={hoveredBoolean}>
 		<div class="entry-prefix">
 			<span class="encircled-text">
-				{ dijkring }
+				{dijkring}
 			</span>
 		</div>
 		<div class="entry-body">
-			<div>{ name }</div>
+			<div>{name}</div>
 		</div>
 		{#if activeBoolean}
 			<Button

--- a/src/lib/components/map-cesium/MapToolFlooding/MapToolFlooding.svelte
+++ b/src/lib/components/map-cesium/MapToolFlooding/MapToolFlooding.svelte
@@ -1,290 +1,98 @@
 <script lang="ts">
 	import { getContext } from "svelte";
 	import { writable, get, type Writable } from "svelte/store";
+	import { _ } from "svelte-i18n";
 	import { WaveHeight } from "carbon-icons-svelte";
 	import { Search, Dropdown } from "carbon-components-svelte";
-	import { _ } from "svelte-i18n";
 	import { MapToolMenuOption } from "$lib/components/ui/components/MapToolMenu/MapToolMenuOption";
-	import { LayerConfig } from "$lib/components/map-core/layer-config";
-	// import type { WfsLayer } from "../module/layers/wfs-layer";
-	import { OgcFeaturesLayer } from "../module/layers/ogc-features-layer";
-	import type { IconLayer } from "../module/layers/icon-layer";
 	import BreachEntry from "./BreachEntry.svelte";
-	import type { CesiumIcon } from "../module/cesium-icon";
 	import LayerControlFlood from "../LayerControlFlood/LayerControlFlood.svelte";
-	import { FloodLayer } from "../module/layers/flood-layer";
-	import * as Cesium from "cesium";
+	import { FloodLayerController, type Breach, type FloodToolSettings } from "./layer-controller";
 
 	const { registerTool, selectedTool, map } = getContext<any>("mapTools");
 
 	const id: string = "flooding";
 	const icon: any = WaveHeight;
-	let label: string = $_("tools.flooding.label");
-	let showOnBottom: boolean = false;
+	const label: string = $_("tools.flooding.label");
+	const showOnBottom: boolean = false;
 
-	let tool = new MapToolMenuOption(id, icon, label, showOnBottom);
-	$: settings = tool.settings;
+	const tool = new MapToolMenuOption(id, icon, label, showOnBottom);
+	registerTool(tool);
 
-	tool.settings.subscribe((settings) => {
-        if (settings) {
-			console.log(settings)
-			iconLayer = addIconLayer();
-			// roadsLayer = addAllRoadsLayer(); // Takes too long to load currently
-        }
-    });
 
-	$: tool.label.set($_("tools.flooding.label"));
+	const selectedScenario: Writable<string | undefined> = writable(undefined);
 
-	let iconLayer: IconLayer;
-	let allRoadsLayer: OgcFeaturesLayer;
-	let floodLayer: FloodLayer | undefined;
-	let floodedRoadsLayer: OgcFeaturesLayer | undefined;
-	let layerControlRef;
+	let breaches: Array<Breach>;
+	const activeBreach: Writable<Breach | undefined> = writable(undefined);
+	const hoveredBreach: Writable<Breach | undefined> = writable(undefined);
+
+	let floodLayerController: FloodLayerController | undefined;
 	
-	$: active = iconLayer.activeIcon;
-	$: hovered = iconLayer.hoveredIcon;
-	$: breaches = iconLayer.mapIcons;
+	tool.settings.subscribe(async(settings?: FloodToolSettings) => {
+		if (settings) {
+			floodLayerController = new FloodLayerController(map, settings, activeBreach, selectedScenario);
+			const breachCollection = await fetch(settings.breachUrl).then((res) => res.json());
+			breaches = breachCollection.features;
+			floodLayerController.addBreaches(breaches);
+			setSearchResults();
+		}
+	});
 
-	let searchString: Writable<string> = writable<string>("");
-    let searchableList: Array<{ key: string; value: CesiumIcon }> = new Array<{ key: string; value: CesiumIcon }>();
-    let searchResults: Array<CesiumIcon> = new Array<CesiumIcon>();
+	const searchString: Writable<string> = writable<string>("");
+	let searchableList: Array<{ key: string; value: Breach }> = new Array<{ key: string; value: Breach }>();
+	let searchResults: Array<Breach> = new Array<Breach>();
 
-	let scenario: Writable<string> = writable()
-
-	function searchBreach() {
+	function setSearchResults(): void {
 		if (!breaches) return;
-		searchableList = $breaches.map((b) => ({ key: b.properties.name.toLowerCase(), value: b }));
+		searchableList = breaches.map((b) => ({ key: b.properties.name.toLowerCase(), value: b }));
 		searchResults = searchableList.filter((item) => item.key.toLowerCase().includes(get(searchString).toLowerCase()) || get(searchString) === "")
 			.sort((a, b) => a.key.localeCompare(b.key))
 			.map((item) => item.value);
 	}
 
 	searchString.subscribe(() => {
-		searchBreach();
+		setSearchResults();
 	});
 
 	selectedTool.subscribe((selected: MapToolMenuOption) => {
 		if (selected === tool) {
-			iconLayer.show();
-			zoomToLayer();
-		} else {
-			if (iconLayer) iconLayer.hide();
+			floodLayerController?.showAll();
 		}
 	});
-
-	$: iconLayer.loaded.subscribe((loaded) => {
-		if (loaded) {
-			zoomToLayer();
-			searchBreach();
-		}
-	});
-
-
-	function zoomToLayer() {
-		const pos = iconLayer.getLayerPosition();
-		if (pos) map.flyTo(pos);
-	}
-
-	function addIconLayer() {
-		// add icon layer with breach locations
-		const layerConfig = new LayerConfig({
-			id: "fl_breachicons",
-			title: "Breach Locations",
-			type: "icon",
-			settings: {
-                "url": get(tool.settings).breachUrl
-            },
-			isBackground: false,
-			defaultOn: true,
-			defaultAddToManager: false,
-		});
-		return map.addLayer(layerConfig);
-	}
-
-	function addAllRoadsLayer() {
-		let breach = get(iconLayer.activeIcon);
-		if (!breach) return;
-
-		// add roads layer with all roads
-		const layerConfig = new LayerConfig({
-			id: "all_roads",
-			title: "Wegen",
-			type: "ogc-features",
-			settings: {
-				"url": "http://localhost:5000/",
-                "options": {
-                    "collectionId": "nwb",
-                    "heightStartLoading": 50000,
-                    "maxFeatures": 10,
-                    "tileWidth": 1024
-                }
-			},
-			isBackground: false,
-			defaultOn: true,
-			defaultAddToManager: false,
-		});
-		return map.addLayer(layerConfig);
-	}
-
-	$: iconLayer.activeIcon.subscribe((breach) => {
-		if (!breach) {
-			removeFloodLayer();
-			return;
-		}
-		// set current scenario to first in list
-		scenario.set(breach.properties.scenarios[0]);
-	});
-
-	$: scenario.subscribe(() => {
-		if (!get(iconLayer.activeIcon)) {
-			return;
-		}
-		addFloodsAndRoads();
-	});
-
-	async function addFloodsAndRoads() {
-		let breach = get(iconLayer.activeIcon);
-		if (!breach) return;
-
-		// Fly to breach location
-		await map.viewer.flyTo(breach.billboard, {
-				duration: 3,
-				offset: new Cesium.HeadingPitchRange(0, Cesium.Math.toRadians(-60), 5000)
-			});
-		addFloodLayer(breach);
-		addFloodedRoadsLayer(breach);
-	}
-
-	function addFloodLayer(breach) {
-		// add flood layer for specific scenario 
-
-		let layerId = `${breach.properties.dijkring}_${breach.properties.name}_${get(scenario)}`;
-		if (floodLayer?.config?.id !== layerId) {
-			removeFloodLayer();
-			try {
-				floodLayer = map.addLayer(new LayerConfig({
-					id: layerId,
-					type: "flood",
-					title: "Flood layer",
-					groupId: "",
-					legendUrl: "",
-					isBackground: false,
-					defaultAddToManager: true,
-					defaultOn: true,
-					transparent: false,
-					opacity: 0,
-					settings: {
-						url: `${$settings.scenariosBaseUrl}${layerId}/layer.json`,
-						resolution: 50
-					}
-				}));
-
-			} catch (error) {
-				console.error(error);
-			}
-		}
-	console.log("added flood layer")
-	}
-
-	function addFloodedRoadsLayer(breach) {
-		// add flooded roads for specific scenario from OGC feature API
-		
-		let layerId = `${breach.properties.dijkring}_${breach.properties.name}_${get(scenario)}`;
-		// get(timeSliderValue);
-		console.log(layerId);
-		
-		if (floodedRoadsLayer?.config?.id !== layerId) {
-			removeFloodedRoadsLayer();
-		
-			try {
-					floodedRoadsLayer = map.addLayer(new LayerConfig({
-					id: "flooded_roads",
-					title: "Wegen",
-					type: "ogc-features",
-					settings: {
-						"url": `http://localhost:5000`,
-						"options": {
-							"collectionId": "nwb_floods",
-							"heightStartLoading": 50000,
-							"maxFeatures": 10000,
-							"tileWidth": 40640
-						},
-						"parameters": { 
-							"scenario": "26_NzSch-dp_160_300",
-							// "scenario": layerId, // scenario not yet formatted correctly in data
-							"timestep": "01440",
-							"limit": "1420"
-						}
-					},
-					isBackground: false,
-					defaultOn: true,
-					defaultAddToManager: false
-					}))
-			} catch (error) {
-					console.error(error);
-			}
-		}
-		console.log("added flooded roads layer")
-	}
-
-	function removeFloodLayer() {
-		if (floodLayer) {
-			floodLayer.hide();
-			floodLayer.removeFromMap();
-			floodLayer = undefined;
-			// layerControlRef.$destroy();
-			// layerControlRef was destroyed but never instantiated again, so it breaks
-			console.log("removed flood layer")
-		}
-	}
-
-	function removeFloodedRoadsLayer() {
-		if (floodedRoadsLayer) {
-			floodedRoadsLayer.hide();
-			floodedRoadsLayer.removeFromMap();
-			floodedRoadsLayer = undefined;
-			console.log("removed flooded roads layer")
-		}
-	}
-
-	registerTool(tool);
-
 
 </script>
 
 
-{#if $selectedTool === tool}
+{#if $selectedTool === tool && floodLayerController}
 	<div class="wrapper">
 		<div class="selected-content">
 			<div class="bx--label">Gekozen bres</div>
-			{#if $active !== undefined}
-				<BreachEntry
-					bind:breach={$active}
-					bind:active
-					bind:hovered
-				>
-					<svelte:fragment slot="info"> 
-						{#if $active }
+			{#if $activeBreach}
+				{#key $activeBreach}
+					<BreachEntry
+						breach={$activeBreach}
+						active={activeBreach}
+						hovered={hoveredBreach}
+					>
+						<svelte:fragment slot="info"> 
 							<div class="info-content">
 								<Dropdown
 									label={$_("tools.flooding.scenario")}
-									items={$active.properties.scenarios.map((sc) => ({ id: sc, text: "1:" + sc }))}
-									bind:selectedId={$scenario}
+									items={$activeBreach.properties.scenarios.map((sc) => ({ id: sc, text: "1:" + sc }))}
+									bind:selectedId={$selectedScenario}
 									titleText={$_("tools.flooding.scenario")}
 								/>
-								{#if floodLayer !== undefined}
+								{#if $selectedScenario}
 									<LayerControlFlood
-										bind:this={layerControlRef}
-										layer={floodLayer}
+										{floodLayerController}
 										map={map}
 										showGlobeOpacitySlider={true}
 									/>
 								{/if}
 							</div>
-						{/if}
-					</svelte:fragment>
-					
-				</BreachEntry>
+						</svelte:fragment>
+					</BreachEntry>
+				{/key}
 			{:else}
 				<div>
 					Geen bres geselecteerd
@@ -301,12 +109,12 @@
 				{#if searchResults.length === 0}
 					<div>Geen resultaten</div>
 				{/if}
-				{#each searchResults as breach}
-					{#if breach && (!$active || breach !== $active)}
+				{#each searchResults as breach (breach.properties.name)}
+					{#if breach && (!$activeBreach || breach !== $activeBreach)}
 						<BreachEntry
 							bind:breach
-							bind:active
-							bind:hovered
+							active={activeBreach}
+							hovered={hoveredBreach}
 						/>
 					{/if}
 				{/each}

--- a/src/lib/components/map-cesium/MapToolFlooding/MapToolFlooding.svelte
+++ b/src/lib/components/map-cesium/MapToolFlooding/MapToolFlooding.svelte
@@ -60,6 +60,13 @@
 		}
 	});
 
+	activeBreach.subscribe((breach) => {
+		if (breach && !$selectedTool) {
+			$selectedTool = tool
+		}
+	});
+	
+
 </script>
 
 

--- a/src/lib/components/map-cesium/MapToolFlooding/layer-controller.ts
+++ b/src/lib/components/map-cesium/MapToolFlooding/layer-controller.ts
@@ -1,0 +1,203 @@
+import type { Map } from "../module/map";
+import { LayerConfig } from "$lib/components/map-core/layer-config";
+import type { IconLayer } from "../module/layers/icon-layer";
+import type { FloodLayer } from "../module/layers/flood-layer";
+import type { OgcFeaturesLayer } from "../module/layers/ogc-features-layer";
+import { get, writable, type Writable } from "svelte/store";
+import { LayerConfigGroup } from "$lib/components/map-core/layer-config-group";
+
+
+export interface FloodToolSettings {
+	scenariosBaseUrl: string;
+	breachUrl: string;
+	roadsUrl: string;
+}
+
+export interface Breach {
+	type: string;
+	geometry: {
+		type: string;
+		coordinates: Array<number>;
+	};
+	properties: {
+		name: string;
+		dijkring: string;
+		scenarios: Array<string>;
+	};
+}
+
+
+export class FloodLayerController {
+
+	private map: Map;
+	public activeBreach: Writable<Breach | undefined>;
+	public selectedScenario: Writable<string | undefined> = writable(undefined);
+	
+	public time: Writable<number> = writable(0);
+	public minTime: Writable<number> = writable(0);
+	public maxTime: Writable<number> = writable(1);
+	public speed: Writable<number> = writable(0.1);
+
+	public opacity: Writable<number> = writable(1);
+
+	public layerConfigGroup: LayerConfigGroup = new LayerConfigGroup("overstromingen", "Overstromingen");
+	public iconLayer: IconLayer<Breach>;
+	public floodLayer: FloodLayer;
+	//public roadsLayer?: OgcFeaturesLayer;
+	public floodedRoadsLayer: OgcFeaturesLayer;
+
+	constructor(map: Map, settings: FloodToolSettings, activeBreach: Writable<Breach | undefined>, selectedScenario: Writable<string | undefined>) {
+		this.map = map;
+		this.activeBreach = activeBreach;
+		this.selectedScenario = selectedScenario;
+		this.map.layerLibrary.addLayerConfigGroup(this.layerConfigGroup);
+		this.iconLayer = this.addIconLayer();
+		this.floodLayer = this.addFloodLayer(settings.scenariosBaseUrl);
+		this.floodedRoadsLayer = this.addFloodedRoadsLayer("http://localhost:5000");
+
+		this.activeBreach.subscribe(() => {
+			this.selectedScenario.set(undefined);
+			this.floodLayer.clear();
+			this.time.set(0);
+		});
+		this.selectedScenario.subscribe((scenario) => {
+			const breach = get(this.activeBreach);
+			if (breach && scenario) {
+				this.loadNewScenario(breach, scenario);
+			}
+		});
+	}
+
+	public showAll(): void {
+		this.iconLayer?.show();
+		this.floodLayer?.show();
+		//this.roadsLayer?.show();
+		this.floodedRoadsLayer?.show();
+	}
+
+	
+	public addBreaches(breaches: Array<Breach>): void {
+		this.iconLayer?.loadFeatures(breaches);
+	}
+
+	public async loadNewScenario(breach: Breach, scenario: string): Promise<void> {
+		if (this.floodLayer) {
+			this.floodLayer.loadScenario(breach, scenario).then(() => {
+				const numberOfSteps = this.floodLayer.source?.waterLevels.length;
+				this.maxTime.set(numberOfSteps);
+			});
+		}
+		
+		const scenarioId = `${breach.properties.dijkring}_${breach.properties.name}_${scenario}`;
+		const endpoint = `${scenarioId}/layer.json`;
+		const parameters = {
+			scenario: breach.properties.scenarios[0],
+			timestep: "01188",
+			limit: "1420"
+		}
+		this.floodedRoadsLayer?.source.switchUrl(endpoint, parameters);
+	}
+
+	private addIconLayer(): IconLayer<Breach> {
+		// add icon layer with breach locations
+		const layerConfig = new LayerConfig({
+			id: "fl_breachicons",
+			title: "Breach Locations",
+			type: "icon",
+			groupId: this.layerConfigGroup.id,
+			isBackground: false,
+			defaultOn: true,
+			defaultAddToManager: true,
+		});
+		//const layer = this.map.addLayer(layerConfig) as IconLayer<Breach>;
+		this.map.layerLibrary.addLayerConfig(layerConfig);
+		layerConfig.added.set(true);
+		const layer = get(this.map.layers).find((l) => l.id === layerConfig.id) as IconLayer<Breach>;
+		layer.activeStore = this.activeBreach;
+		return layer;
+	}
+
+	private addFloodLayer(baseUrl: string): FloodLayer {
+		const layerConfig = new LayerConfig({
+			id: "flood_layer_fier",
+			type: "flood",
+			title: "Flood layer",
+			groupId: this.layerConfigGroup.id,
+			legendUrl: "",
+			isBackground: false,
+			defaultAddToManager: true,
+			defaultOn: true,
+			transparent: false,
+			opacity: 0,
+			settings: {
+				resolution: 50,
+				url: baseUrl
+			}
+		});
+		this.map.layerLibrary.addLayerConfig(layerConfig);
+		layerConfig.added.set(true);
+		const floodLayer = get(this.map.layers).find((l) => l.id === layerConfig.id) as FloodLayer;
+		floodLayer.time = this.time;
+		floodLayer.opacity = this.opacity;
+		return floodLayer;
+	}
+
+	/*
+	public addRoadsLayer(): void {
+		const layerConfig = new LayerConfig({
+			id: "all_roads",
+			title: "Wegen",
+			type: "ogc-features",
+			settings: {
+				"url": "http://localhost:5000/",
+				"options": {
+					"collectionId": "nwb",
+					"heightStartLoading": 50000,
+					"maxFeatures": 10,
+					"tileWidth": 1024
+				}
+			},
+			isBackground: false,
+			defaultOn: true,
+			defaultAddToManager: false,
+		});
+		this.roadsLayer = this.map.addLayer(layerConfig) as OgcFeaturesLayer;
+		this.roadsLayer.opacity = this.opacity;
+	}
+	*/
+
+	private addFloodedRoadsLayer(baseUrl: string): OgcFeaturesLayer {
+		const layerConfig = new LayerConfig({
+			id: "flooded_roads",
+			title: "Wegen",
+			type: "ogc-features",
+			groupId: this.layerConfigGroup.id,
+			settings: {
+				url: baseUrl,
+				options: {
+					collectionId: "nwb_floods",
+					heightStartLoading: 50000,
+					maxFeatures: 10000,
+					tileWidth: 40640
+				},
+				parameters: { 
+					scenario: "26_NzSch-dp_160_300",
+					// "scenario": layerId, // scenario not yet formatted correctly in data
+					timestep: "01440",
+					limit: "1420"
+				},
+				hideInLayerManager: false,
+				dragDropped: false
+	
+			},
+			isBackground: false,
+			defaultOn: true,
+			defaultAddToManager: true
+		});
+		this.map.layerLibrary.addLayerConfig(layerConfig);
+		layerConfig.added.set(true);
+		const floodedRoadsLayer = get(this.map.layers).find((l) => l.id === layerConfig.id) as OgcFeaturesLayer;
+		floodedRoadsLayer.opacity = this.opacity;
+		return floodedRoadsLayer;
+	}
+}

--- a/src/lib/components/map-cesium/module/cesium-icon.ts
+++ b/src/lib/components/map-cesium/module/cesium-icon.ts
@@ -1,14 +1,12 @@
 import { get, writable, type Unsubscriber, type Writable } from "svelte/store";
 import * as Cesium from "cesium";
-
-import type { Map } from "$lib/components/map-cesium/module/map";
 import type { GeographicLocation } from "$lib/components/map-core/geographic-location";
 
 
-export class CesiumIcon {
-	private map: Map;
+export class CesiumIcon<F> {
+
 	public location: GeographicLocation;
-	public properties: object;
+	public feature: F;
 	public billboard!: Cesium.Entity;
 
 	private icon: string;
@@ -28,17 +26,15 @@ export class CesiumIcon {
 	private showUnsubscriber!: Unsubscriber;
 
 	constructor(
-		map: Map,
 		location: GeographicLocation,
-		properties: object,
+		feature: F,
 		icon: string,
 		color: Cesium.ConstantProperty,
 		activeColor: Cesium.ConstantProperty,
 		show: boolean
 	) {
-		this.map = map;
 		this.location = location;
-		this.properties = properties;
+		this.feature = feature;
 		this.icon = icon;
 		this.color = color;
 		this.activeColor = activeColor;
@@ -50,7 +46,7 @@ export class CesiumIcon {
 
 		this.hoveredUnsubscriber = this.hovered.subscribe((hovered) => {
 			if (this.billboard.billboard) {
-				this.billboard.billboard.color = get(this.hovered) || get(this.active) ? this.activeColor : this.color;
+				this.billboard.billboard.color = hovered || get(this.active) ? this.activeColor : this.color;
 			}
 		});
 
@@ -70,7 +66,6 @@ export class CesiumIcon {
 	}
 
 	public removeItem(): void {
-		this.map.viewer.entities.remove(this.billboard);
 		this.hoveredUnsubscriber();
 		this.activeUnsubscriber();
 		this.showUnsubscriber();
@@ -98,6 +93,6 @@ export class CesiumIcon {
 				heightReference: Cesium.HeightReference.RELATIVE_TO_GROUND,
 			}
 		});
-		this.map.viewer.entities.add(this.billboard);
 	}
+
 }

--- a/src/lib/components/map-cesium/module/layers/icon-layer.ts
+++ b/src/lib/components/map-cesium/module/layers/icon-layer.ts
@@ -12,117 +12,142 @@ import { getCartesian2 } from "$lib/components/map-cesium/module/utils/geo-utils
 import { getCameraPositionFromBoundingSphere } from "../utils/layer-utils";
 
 
-export class IconLayer extends CustomLayer {
+export class IconLayer<F> extends CustomLayer {
 
-    public hoveredIcon: Writable<CesiumIcon | undefined> = writable(undefined);
-    public activeIcon: Writable<CesiumIcon | undefined> = writable(undefined);
-    public loaded: Writable<boolean> = writable(false);
-    public mapIcons: Writable<Array<CesiumIcon>> = writable(new Array<CesiumIcon>());
-    private unsubscribers: Array<Unsubscriber> = new Array<Unsubscriber>();
+	public hoveredFeature: Writable<F | undefined> = writable(undefined);
+	public activeFeature: Writable<F | undefined> = writable(undefined);
+	public mapIcons: Array<CesiumIcon<F>> = [];
+	private unsubscribers: Array<Unsubscriber> = new Array<Unsubscriber>();
 
-    public colorProperties = {
-        custom: new Cesium.ConstantProperty(Cesium.Color.LIGHTGRAY),
-        active: new Cesium.ConstantProperty(Cesium.Color.LIGHTSKYBLUE),
-    }
+	public colorProperties = {
+		custom: new Cesium.ConstantProperty(Cesium.Color.LIGHTGRAY),
+		active: new Cesium.ConstantProperty(Cesium.Color.LIGHTSKYBLUE),
+	}
 
-    constructor(map: Map, config: LayerConfig) {
+	constructor(map: Map, config: LayerConfig) {
 		super(map, config);
-
+		this.source = new Cesium.CustomDataSource(config.id);
 		this.addListeners();
-        this.addMouseEvents();
-        this.loadData();
+		this.addMouseEvents();
 	}
 
-    private addListeners() {
-        this.unsubscribers.push(
-            this.hoveredIcon.subscribe((icon) => {
-                get(this.mapIcons).forEach((i) => i.hovered.set(i === icon));
-                this.map.refresh();
-            }),
-            this.activeIcon.subscribe((icon) => {
-                get(this.mapIcons).forEach((i) => i.active.set(i === icon));
-                this.map.refresh();
-            })
-        );
-    }
+	private addListeners() {
+		this.unsubscribers.forEach((unsubscriber) => unsubscriber());
+		this.unsubscribers.push(
+			this.hoveredFeature.subscribe((feature) => {
+				this.mapIcons.forEach((i) => i.hovered.set(i.feature === feature));
+				this.map.refresh();
+			}),
+			this.activeFeature.subscribe((feature) => {
+				this.mapIcons.forEach((i) => i.active.set(i.feature === feature));
+				this.map.refresh();
+				if (feature) this.flyToFeature(feature);
+			})
+		);
+	}
 
-    private async loadData() {
-        await fetch(this.config.settings["url"])
-            .then(response => response.json())
-            .then(data => {
-                // extract locations from GeoJSON features and create CesiumIcon objects
-                let mapIcons: Array<CesiumIcon> = [];
-                data.features.map((feature: any) => {
-                    const location = new GeographicLocation(feature.geometry.coordinates[0], feature.geometry.coordinates[1]);
-                    const properties = feature.properties;
-                    const icon = new CesiumIcon(this.map, location, properties, breachIcon, this.colorProperties.custom, this.colorProperties.active, false);
-                    mapIcons.push(icon);
-                    return location;
-                });
-                this.mapIcons.set(mapIcons);
-                this.setCameraPosition();
-                this.loaded.set(true);
-            })
-    }
+	set activeStore(value: Writable<F | undefined>) {
+		this.activeFeature = value;
+		this.addListeners();
+	}
+
+	public loadFeatures(items: Array<F>): void {
+		// extract locations from GeoJSON features and create CesiumIcon objects
+		const mapIcons: Array<CesiumIcon<F>> = [];
+		items.map((feature: any) => {
+			const location = new GeographicLocation(feature.geometry.coordinates[0], feature.geometry.coordinates[1]);
+			const icon = new CesiumIcon(location, feature, breachIcon, this.colorProperties.custom, this.colorProperties.active, false);
+			mapIcons.push(icon);
+			return location;
+		});
+		this.addMapEntities(mapIcons);
+		this.setCameraPosition();
+		this.zoomToLayer();
+	}
 
 
-    public destroy() {
-        this.unsubscribers.forEach((unsubscriber) => unsubscriber());
-        this.clearMapEntities();
+	public destroy() {
+		this.unsubscribers.forEach((unsubscriber) => unsubscriber());
+		this.clearMapEntities();
 		this.removeMouseEvents();
-    }
-
-    private clearMapEntities(): void {
-        get(this.mapIcons).forEach((item) => item.removeItem());
-        this.mapIcons.set(new Array());
-        this.removeMouseEvents();
-    }
-
-    private getObjectFromMouseLocation(m: any): CesiumIcon | undefined {
-        const location = getCartesian2(m);
-        if (!location) return undefined;
-        const picked = this.map.viewer.scene.pick(location);
-        if (picked?.id?.billboard !== undefined) {
-            const billboard = picked.id.billboard as Cesium.BillboardGraphics;
-            for (const icon of get(this.mapIcons)) {
-                if (billboard === icon.billboard.billboard) {
-                    return icon;
-                }
-            }
-            return undefined;
-        }
-    }
-
-    private moveHandle = (m: any) => {
-        const obj = this.getObjectFromMouseLocation(m);
-        if (obj !== get(this.hoveredIcon)) this.hoveredIcon.set(obj);
-        this.map.container.style.cursor = obj ? "pointer" : "default";
-    }
-    private leftClickHandle = (m: any) => {
-        const obj = this.getObjectFromMouseLocation(m);
-        if (obj !== get(this.activeIcon) && obj !== undefined) this.activeIcon.set(obj);
-    }
-
-    private addMouseEvents(): void {
-        this.map.on("mouseLeftClick", this.leftClickHandle);
-        this.map.on("mouseMove", this.moveHandle);
-    }
-    private removeMouseEvents(): void {
-        this.map.off("mouseLeftClick", this.leftClickHandle);
-        this.map.off("mouseMove", this.moveHandle);
-    }
-
-    public setCameraPosition(): void {
-		const cartesians = get(this.mapIcons).map(i => i.billboard.position?.getValue()).filter(c => c !== undefined);
-		const sphere = Cesium.BoundingSphere.fromPoints(cartesians);
-        this.config.cameraPosition = getCameraPositionFromBoundingSphere(sphere);
 	}
 
-    public show(): void {
-        if (get(this.loaded)) get(this.mapIcons).forEach((icon) => icon.show.set(true));
+	private addMapEntities(newIcons: Array<CesiumIcon<F>>): void {
+		this.mapIcons.push(...newIcons);
+		newIcons.forEach((icon) => {
+			this.source.entities.add(icon.billboard);
+		});
+	}
+
+	private clearMapEntities(): void {
+		this.source.entities.removeAll();
+		this.mapIcons = [];
+		this.removeMouseEvents();
+	}
+
+	private getObjectFromMouseLocation(m: any): F | undefined {
+		const location = getCartesian2(m);
+		if (!location) return undefined;
+		const picked = this.map.viewer.scene.pick(location);
+		if (picked?.id?.billboard !== undefined) {
+			const billboard = picked.id.billboard as Cesium.BillboardGraphics;
+			for (const icon of this.mapIcons) {
+				if (billboard === icon.billboard.billboard) {
+					return icon.feature;
+				}
+			}
+			return undefined;
+		}
+	}
+
+	private moveHandle = (m: any) => {
+		const obj = this.getObjectFromMouseLocation(m);
+		if (obj !== get(this.hoveredFeature)) this.hoveredFeature.set(obj);
+		this.map.container.style.cursor = obj ? "pointer" : "default";
+	}
+	private leftClickHandle = (m: any) => {
+		const obj = this.getObjectFromMouseLocation(m);
+		if (obj !== get(this.activeFeature) && obj !== undefined) this.activeFeature.set(obj);
+	}
+
+	private addMouseEvents(): void {
+		this.map.on("mouseLeftClick", this.leftClickHandle);
+		this.map.on("mouseMove", this.moveHandle);
+	}
+	private removeMouseEvents(): void {
+		this.map.off("mouseLeftClick", this.leftClickHandle);
+		this.map.off("mouseMove", this.moveHandle);
+	}
+
+	public setCameraPosition(): void {
+		const cartesians = this.mapIcons.map(i => i.billboard.position?.getValue()).filter(c => c !== undefined);
+		const sphere = Cesium.BoundingSphere.fromPoints(cartesians);
+		this.config.cameraPosition = getCameraPositionFromBoundingSphere(sphere);
+	}
+
+	public show(): void {
+		this.mapIcons?.forEach((icon) => icon.show.set(true));
+		this.map?.refresh();
 	}
 
 	public hide(): void {
-		if (get(this.loaded)) get(this.mapIcons).forEach((icon) => icon.show.set(false));
+		this.mapIcons?.forEach((icon) => icon.show.set(false));
+		this.map?.refresh();
+	}
+
+	public zoomToLayer(): void {
+		const allBillboards = this.mapIcons.map((i) => i.billboard);
+		this.map.viewer.flyTo(allBillboards, {
+			duration: 1.5
+		});
+		this.show();
+	}
+
+	public flyToFeature(feature: F): void {
+		const icon = this.mapIcons.find((i) => i.feature === feature);
+		if (!icon) return;
+		this.map.viewer.flyTo(icon.billboard, {
+			duration: 1
+		});
 	}
 }

--- a/src/lib/components/map-cesium/module/layers/ogc-features-layer.ts
+++ b/src/lib/components/map-cesium/module/layers/ogc-features-layer.ts
@@ -3,18 +3,17 @@ import type { Map } from "../map";
 
 import { OgcFeaturesProviderCesium } from "../providers/ogc-features-provider";
 import { CesiumLayer } from "./cesium-layer";
-import { get } from "svelte/store";
 
 
 export class OgcFeaturesLayer extends CesiumLayer<OgcFeaturesProviderCesium> {
 
-    constructor(map: Map, config: LayerConfig, timesliderValue: Writable<number>) {
+	constructor(map: Map, config: LayerConfig) {
         super(map, config);
-        this.source = new OgcFeaturesProviderCesium(this.config.settings.url, this.config.settings.options, timesliderValue, this.config.settings.parameters);
+        this.source = new OgcFeaturesProviderCesium(map, this.config.settings.url, this.config.settings.options, this.config.settings.parameters);
     }
 
     public async addToMap(): Promise<void> {
-        this.source.addToMap(this.map, get(this.visible));
+        this.source.init();
     }
 
     public removeFromMap(): void {

--- a/src/lib/components/map-cesium/module/providers/ogc-features-provider.ts
+++ b/src/lib/components/map-cesium/module/providers/ogc-features-provider.ts
@@ -1,9 +1,7 @@
+import type { Unsubscriber } from "svelte/store";
 import * as Cesium from "cesium";
 import type { Map } from "../map";
-import type { Unsubscriber } from "svelte/motion";
 import * as turf from "@turf/turf";
-import { time } from "svelte-i18n";
-import type { Writable } from "svelte/store";
 
 
 interface OgcFeaturesTile {
@@ -19,7 +17,12 @@ interface OgcFeaturesTile {
 interface Collection {
 	id: string;
 	title: string;
-	bbox: [number, number, number, number];
+	description?: string;
+	extent: {
+		spatial: {
+			bbox: Array<[number, number, number, number]>;
+		}
+	}
 }
 
 interface OgcFeaturesConstructorOptions {
@@ -47,6 +50,7 @@ interface OgcFeaturesConstructorOptions {
 
 export class OgcFeaturesProviderCesium {
 
+	public map: Map;
 	private url: string;
 	public options: Partial<OgcFeaturesConstructorOptions>;
 	public parameters: Record<string, string> | undefined;
@@ -58,7 +62,6 @@ export class OgcFeaturesProviderCesium {
 	public maxFeatures: number = 1000;
 	public boundingRect: Cesium.Rectangle = Cesium.Rectangle.MAX_VALUE;
 
-	public map!: Map;
 	public dynamicLoading: boolean = false;
 	private OgcFeaturesLoaderCesium!: OgcFeaturesLoaderCesium;
 	public allowPicking: boolean;
@@ -66,44 +69,49 @@ export class OgcFeaturesProviderCesium {
 	public setupPromise: Promise<void> | undefined;
 	public showing: boolean = false;
 
-	public timeSliderValue: Writable<number> | undefined;
-
-	constructor(url: string, options: Partial<OgcFeaturesConstructorOptions>, timeSliderValue?: Writable<number>, parameters?: Record<string, string>) {
+	constructor(map: Map, url: string, options: Partial<OgcFeaturesConstructorOptions>, parameters?: Record<string, string>) {
 		const {
 			collectionId = "",
 			allowPicking = true
         } = options;
 
 		// todo: parse URL to recognize if it already contains the collection name (e.g. /collections/{collection}/items)
+		this.map = map;
 		this.url = url;
 		this.options = options;
 		this.parameters = parameters;
 
 		this.collectionId = collectionId;
 		this.allowPicking = allowPicking;
-		this.timeSliderValue = timeSliderValue;
 	}
 
-
-	public addToMap(map: Map, show: boolean = true): void {
-		this.map = map;
-		if (show) this.show();
-	}
-
-	public async show(): Promise<void> {
+	public async init(): Promise<void> {
 		this.showing = true;
-        // check if already loaded and showing
-		if (this.OgcFeaturesLoaderCesium && this.map.viewer.scene.primitives.contains(this.OgcFeaturesLoaderCesium.primitiveCollection) && this.OgcFeaturesLoaderCesium.primitiveCollection.show) return;
+		this.OgcFeaturesLoaderCesium?.destroy();
 		await this.setup();
-		if (!this.showing) return; // If hide() was called before setup was done
-		this.OgcFeaturesLoaderCesium.activate();
+		if (this.showing) { // If hide() may have been called before setup was done
+			this.show();
+		}
+	}
+	
+	public switchUrl(url: string, parameters?: Record<string, string>): void {
+		if (url !== this.url || parameters !== this.parameters) {
+			this.url = url;
+			this.parameters = parameters;
+			this.init();
+		}
+	}
+
+	public show(): void {
+		this.showing = true;
+		this.OgcFeaturesLoaderCesium?.activate();
 		this.map.refresh();
 	}
 
 	public hide(): void {
 		this.showing = false;
 		this.OgcFeaturesLoaderCesium?.deactivate();
-		this.map?.refresh();
+		this.map.refresh();
 	}
 
 	public setOpacity(opacity: number): void {
@@ -135,10 +143,9 @@ export class OgcFeaturesProviderCesium {
 		try {
 			const req = await fetch(url);
 			const json = await req.json();
-			
-			this.availableCollections = Array.from(json.collections).map(col => {
-				return {id: col.id, title: col.title, bbox: col.extent.spatial.bbox[0]} as Collection
-			}).filter(col => col.id !== "");
+			const collections = json.collections as Array<Collection>;
+
+			this.availableCollections = collections.filter(col => col.id !== "");
 
 			if (this.collectionId) {
 				this.collection = this.availableCollections.find(col => col.id === this.collectionId);
@@ -148,8 +155,8 @@ export class OgcFeaturesProviderCesium {
 				this.collection = this.availableCollections[0];
 			}
 			// set bounding box
-			if (this.collection.bbox) {
-				this.boundingRect = Cesium.Rectangle.fromDegrees(...this.collection.bbox);
+			if (this.collection.extent.spatial.bbox) {
+				this.boundingRect = Cesium.Rectangle.fromDegrees(...this.collection.extent.spatial.bbox[0]);
 			}
 		} catch (error) {
 			console.error(error);
@@ -209,34 +216,6 @@ export class OgcFeaturesProviderCesium {
 	}
 
 
-	public async featuresAtPoint(lon: number, lat: number): Promise<GeoJSONFeature | undefined> {
-		const srsName = 'EPSG:4326';
-		const point = `<gml:Point srsName="${srsName}"><gml:coordinates>${lon},${lat}</gml:coordinates></gml:Point>`;
-		const filter = `<Filter><Intersects><PropertyName>geom</PropertyName>${point}</Intersects></Filter>`;
-		
-		const params = new URLSearchParams({
-			service: 'WFS',
-			version: '1.1.0',
-			request: 'GetFeature',
-			typeName: this.featureType,
-			srsName: `EPSG:4326`,
-			maxFeatures: "1", //this.maxFeatures.toString(),
-			outputFormat: 'application/json',
-			Filter: filter
-		});
-
-		try {
-			const response = await fetch(`${this.url}?${params.toString()}`);
-			if (!response.ok) {
-				throw new Error('Network response was not ok');
-			}
-			const feature = await response.json();
-			return feature;
-		} catch (error) {
-			console.error('Error fetching feature:', error);
-		}
-	}
-
 	public async featuresInPolygon(polygon: Array<[lon: number, lat: number]>): Promise<Array<GeoJSONFeature> | undefined> {
 		await this.setup();
 		if (this.OgcFeaturesLoaderCesium instanceof OgcFeaturesLoaderCesiumStatic) {
@@ -268,71 +247,6 @@ export class OgcFeaturesProviderCesium {
 		}
 	}
 
-	public async polygonIntersect2(polygon: Array<[lon: number, lat: number]>): Promise<string | undefined> {
-		const srsName = 'EPSG:4326';
-		const coords = polygon.map(coord => coord.join(',')).join(' ');
-		const point = `<gml:Polygon xmlns:gml="http://www.opengis.net/gml" srsName="${srsName}"><gml:exterior><gml:LinearRing><gml:posList>${coords}</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>`;
-		const filter = `<ogc:Filter xmlns:ogc="http://www.opengis.net/ogc"><ogc:Intersects><ogc:PropertyName>geom</ogc:PropertyName>${point}</ogc:Intersects></ogc:Filter>`;
-		
-		const params = new URLSearchParams({
-			service: 'WFS',
-			version: '2.0.0',
-			request: 'GetFeature',
-			typeName: this.featureType,
-			srsName: `EPSG:4326`,
-			Filter: filter
-		});
-
-		try {
-			const response = await fetch(`${this.url}`, { //?${params.toString()}
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify({
-					polgyon: this.getPolygonFilter(polygon, this.featureType)
-				})
-			});
-			if (!response.ok) {
-				throw new Error('Network response was not ok');
-			}
-			const features = await response.text();
-			return features;
-		} catch (error) {
-			console.error('Error fetching features:', error);
-		}
-	}
-
-	private getPolygonFilter(coordinates: Array<[lon: number, lat: number]>, layerName: string): string {
-		const gmlCoordinates = coordinates.map(coord => coord.join(',')).join(' ');
-		return `
-			<wfs:GetFeature service="WFS" version="1.1.0"
-				xmlns:wfs="http://www.opengis.net/wfs"
-				xmlns:ogc="http://www.opengis.net/ogc"
-				xmlns:gml="http://www.opengis.net/gml"
-				xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-				xsi:schemaLocation="http://www.opengis.net/wfs
-				http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
-				<wfs:Query typeName="${layerName}">
-					<ogc:Filter>
-						<ogc:Intersects>
-							<ogc:PropertyName>geometry</ogc:PropertyName>
-							<gml:Polygon srsName="EPSG:4326">
-								<gml:outerBoundaryIs>
-									<gml:LinearRing>
-										<gml:coordinates>
-											${gmlCoordinates}
-										</gml:coordinates>
-									</gml:LinearRing>
-								</gml:outerBoundaryIs>
-							</gml:Polygon>
-						</ogc:Intersects>
-					</ogc:Filter>
-				</wfs:Query>
-			</wfs:GetFeature>
-		`
-	}
-
 }
 
 
@@ -356,6 +270,7 @@ abstract class OgcFeaturesLoaderCesium {
 			mapPrimitives.add(this.primitiveCollection);
 		}
 		this.primitiveCollection.show = true;
+		this.terrainUnsubscriber?.();
 		this.terrainUnsubscriber = this.OgcFeatures.map.options.terrainSwitchReady.subscribe((b) => {
 			const provider = this.OgcFeatures.map.viewer.terrainProvider;
 			if (b && this.cachedTerrainProvider !== provider) {
@@ -372,6 +287,12 @@ abstract class OgcFeaturesLoaderCesium {
 	}
 
 	public onTerrainSwitch(): void {
+		this.primitiveCollection.removeAll();
+	}
+
+	public destroy(): void {
+		this.deactivate();
+		this.loadedFeatures = [];
 		this.primitiveCollection.removeAll();
 	}
 
@@ -397,17 +318,21 @@ abstract class OgcFeaturesLoaderCesium {
 					});
 					break;
                 case 'LineString':
-                    if (perInstanceTerrainSample && this.OgcFeatures.map.viewer.terrainProvider instanceof Cesium.CesiumTerrainProvider) {
+                    /*
+					if (perInstanceTerrainSample && this.OgcFeatures.map.viewer.terrainProvider instanceof Cesium.CesiumTerrainProvider) {
                         let terrainHeight = await Cesium.sampleTerrainMostDetailed(this.OgcFeatures.map.viewer.terrainProvider, [Cesium.Cartographic.fromDegrees(feature.geometry.coordinates[0][0], feature.geometry.coordinates[0][1])]);
                         if (terrainHeight[0]) height = terrainHeight[0].height;
                     }
+					*/
                     await addLineString(feature.geometry.coordinates, height, feature.properties, colorAttribute);
                     break;
 				case 'MultiLineString':
+					/*
 					if (perInstanceTerrainSample && this.OgcFeatures.map.viewer.terrainProvider instanceof Cesium.CesiumTerrainProvider) {
 						let terrainHeight = await Cesium.sampleTerrainMostDetailed(this.OgcFeatures.map.viewer.terrainProvider, [Cesium.Cartographic.fromDegrees(feature.geometry.coordinates[0][0][0], feature.geometry.coordinates[0][0][1])]);
 						if (terrainHeight[0]) height = terrainHeight[0].height;
 					}
+					*/
 					for (let i=0; i < feature.geometry.coordinates.length; i++) {
 						const uniqueProperties = { ...feature.properties, hidden: i };
 						await addLineString(feature.geometry.coordinates[i], height, uniqueProperties, colorAttribute);
@@ -462,7 +387,7 @@ abstract class OgcFeaturesLoaderCesium {
             const positions = coordinates.map(coord => Cesium.Cartesian3.fromDegrees(coord[0], coord[1], height));
             const props = this.OgcFeatures.allowPicking ? properties : undefined;
             const polylineInstance = new Cesium.GeometryInstance({
-                geometry: new Cesium.PolylineGeometry({
+                geometry: new Cesium.GroundPolylineGeometry({
                     positions: positions,
                     width: 2.0
                 }),
@@ -493,10 +418,10 @@ abstract class OgcFeaturesLoaderCesium {
 				translucent: false
 			});
 			primitives.push(
-				new Cesium.Primitive({
+				new Cesium.GroundPrimitive({
 					geometryInstances: polygonInstances,
 					appearance: polygonAppearance,
-					depthFailAppearance: polygonAppearance,
+					//depthFailAppearance: polygonAppearance,
 					releaseGeometryInstances: true,
 					allowPicking: this.OgcFeatures.allowPicking
 				})
@@ -681,7 +606,6 @@ export class OgcFeaturesLoaderCesiumDynamic extends OgcFeaturesLoaderCesium {
 		this.OgcFeatures.map.viewer.scene.camera.changed.removeEventListener(this.loadHandle);
 	}
 
-
 	public onTerrainSwitch(): void {
 		super.onTerrainSwitch();
 		this.loadedTiles = [];
@@ -692,7 +616,6 @@ export class OgcFeaturesLoaderCesiumDynamic extends OgcFeaturesLoaderCesium {
 
 	private async onCameraChanged(): Promise<void> {
 		if (this.blocking || !this.primitiveCollection.show) return;
-		console.log("Camera changed");
 		this.blocking = true;
 		setTimeout(() => this.blocking = false, 3500);
 		await this.bustCache();


### PR DESCRIPTION
Updates and new features include:
1. Cleaned up Svelte reactivity
2. New layer controller class for proper layer/data management
3. Layers are instantiated only once and can also be toggled from layer manager
4. Time stores are shared across the module
5. Icon layer is now generic (not specific for breaches)
6. Separate class for depth probe. Depth properly destroyed when removing layer control.
7. Smaller time steps in flood layer animation for smoother transitions (the shader interpolates between textures)

Still to do:
1. Roads layer through OGC API Features provider. I did already add a function "switchUrl" to be able to change the URL without needed to re-instantiate the layer, and changed to Cesium.GroundPolylineGeometry in order to not need the Cesium.sampleTerrainMostDetailed. But this all needs testing when the service is working.