### PR TITLE
50 flood depth zoom bug

### DIFF
--- a/src/lib/components/localization/json/en.json
+++ b/src/lib/components/localization/json/en.json
@@ -250,6 +250,7 @@
         "flooding": {
             "label": "Flooding",
             "measureDepth": "Measure depth",
+            "measureDepthError": "Zoom in to measure the water depth",
             "waterTransparency": "Water Opacity",
             "scenario": "Scenario",
             "errorCouldNotLoad": "Could not load flooding data",

--- a/src/lib/components/localization/json/fr.json
+++ b/src/lib/components/localization/json/fr.json
@@ -243,6 +243,7 @@
         "flooding": {
             "label": "Inondations",
             "measureDepth": "Mesurer la profondeur",
+            "measureDepthError": "Zoomez pour mesurer la profondeur de l'eau",
             "waterTransparency": "Opacité de l'eau",
             "scenario": "Scénario",
             "errorCouldNotLoad": "Impossible de charger les données d'inondation",

--- a/src/lib/components/localization/json/nl.json
+++ b/src/lib/components/localization/json/nl.json
@@ -258,6 +258,7 @@
             "label": "Overstromingen",
             "measureDepth": "Diepte meten",
             "waterTransparency": "Water Transparantie",
+            "measureDepthError": "Zoom in om de waterdiepte te meten",
             "scenario": "Scenario",
             "errorCouldNotLoad": "Kan overstromingsdata niet laden",
             "hourSinceBreach": "uur na bres",

--- a/src/lib/components/map-cesium/LayerControlFlood/LayerControlFlood.svelte
+++ b/src/lib/components/map-cesium/LayerControlFlood/LayerControlFlood.svelte
@@ -50,6 +50,9 @@
 	const depthGauge = new DepthGauge(map);
 	let depthGaugeEnabled = false;
 
+	// Create a writable store for depthGaugeButtonDisabled
+	$: depthGaugeButtonDisabled = depthGauge.isDisabled;
+
 	$: depthGaugeEnabled ? depthGauge.activate() : depthGauge.deactivate();
 	
 	onDestroy(() => {
@@ -155,6 +158,9 @@
 			/>
 		</div>
 	</div>
+	{#if $depthGaugeButtonDisabled && depthGaugeEnabled}
+		<ErrorMessage message={$_("tools.flooding.measureDepthError")} />
+	{/if}
 {/if}
 
 

--- a/static/fier.config.json
+++ b/static/fier.config.json
@@ -363,6 +363,10 @@
         {
             "id": "geocoder",
             "enabled": true
+        },
+        {
+            "id": "modeswitcher",
+            "enabled": true
         }
     ]
 }


### PR DESCRIPTION
Fixed it. Camera zoom needs to be 1km or closer to the ground to be able to add measurements now. This allows the terrain to load properly and the measurements to be accurate