### PR TITLE
fix labels visible under the donut chart (#262)

### DIFF
--- a/src/lib/components/map-cesium/MapToolStories/StoryChart.svelte
+++ b/src/lib/components/map-cesium/MapToolStories/StoryChart.svelte
@@ -8,11 +8,25 @@
 	let cleanData: Array<{ name: string; value: number }> = [];
 	let color: Array<string>;
 	let toolTipText: string;
+	
+	// labels visible under the donut chart
+	const ALL_GROUPS = ["A", "B", "C", "D", "E"];
+
 
 	if (data) {
 		// Change name 'group' to 'name' for compatibility with echarts
-		cleanData = data.map(item => ({ name: item.group, value: item.value }));
-		color = ['#339966', '#99ffcc', '#ffff99', '#ffcc66', '#9c4110']; // A B C D E colors
+		const fullData = ALL_GROUPS.map(g => {
+			const found = data.find(item => item.group === g);
+			return {
+				name: g,
+				value: found ? found.value : 0
+			};
+		});
+
+		cleanData = fullData;
+
+		// Colors for A–E
+		color = ['#339966', '#99ffcc', '#ffff99', '#ffcc66', '#9c4110']; 
 		toolTipText = '{b}: {d}%'; // Show group name and percentage
 	}
 	else {


### PR DESCRIPTION
This PR fixes issue #262.

The legend under the Klimaatonderlegger donut chart was hiding labels for classes that had no data in the selected project area. The expected behavior is that all class labels (A–E) should always be shown.

What I changed:
- Added a fixed list of classes (A–E).
- Merged incoming data with defaults so missing classes get value 0.
- This keeps the legend consistent even when some classes are not present in the data.

The rest of the chart logic is unchanged.
