### PR TITLE
407 story desc + header color

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Top-level config shape:
 | `startPosition` | Start camera position (below) | object |
 | `startCameraMode3D` | Start in 3D (true) or 2D (false; pitch forced to -90) | boolean |
 | `startToolOpen` | Tool id to open on start (e.g. `layermanager`, `stories`) | string |
-| `colors` | Carbon Design color tokens (see `static/example.config.json` for the full set) | object |
+| `colors` | Carbon Design color tokens plus header colors `header-color` (bar background), `title-color` / `sub-title-color` (any CSS color); see `static/example.config.json` | object |
 | `title` / `subTitle` | Header title / subtitle | string |
 | `logo` | Header logo image URL | string |
 | `logoMarginLeft` / `logoMarginRight` | Header logo margins | string |

--- a/README.md
+++ b/README.md
@@ -117,10 +117,13 @@ The start position of the camera. Since we are using a 3D viewer we need more th
 ```
 
 #### Colors
-Colors for the GUI. The black header cannot be changed currently, this is an open issue for the Carbon Design svelte components devs.
+Colors for the GUI.
 
 |value|description|type|
 |-|-|-|
+|header-color|Background color of the header bar|string|
+|title-color|Color of the title text in the header|string|
+|sub-title-color|Color of the subtitle text in the header|string|
 |ui-background|Default page background|string|
 |interactive-01|Primary interactive color. Primary buttons|string|
 |interactive-02|Secondary interactive color. Secondary button|string|

--- a/src/lib/components/Page.svelte
+++ b/src/lib/components/Page.svelte
@@ -196,7 +196,7 @@
 <CarbonTheme style={light} />
 
 <div class="main">
-	<Header logo={$settings.logo} logoMarginLeft={$settings.logoMarginLeft} logoMarginRight={$settings.logoMarginRight} company={$settings.title} platformName={$settings.subTitle}>
+	<Header logo={$settings.logo} logoMarginLeft={$settings.logoMarginLeft} logoMarginRight={$settings.logoMarginRight} company={$settings.title} platformName={$settings.subTitle} headerColor={$settings.colors?.["header-color"]} titleColor={$settings.colors?.["title-color"]} subTitleColor={$settings.colors?.["sub-title-color"]}>
 		<div slot="headerUtilities">
 			<div class="header-utilities">
 				{#if $enabledTools.includes("geocoder")}

--- a/src/lib/components/header/CarbonHeader.svelte
+++ b/src/lib/components/header/CarbonHeader.svelte
@@ -63,6 +63,9 @@
   export let logo = undefined;
   export let logoMarginLeft = "0rem";
   export let logoMarginRight = "0rem";
+  export let headerColor = "#161616";
+  export let titleColor = "#ffffff";
+  export let subTitleColor = "#ffffff";
 
   import Menu from "carbon-components-svelte/src/icons/Menu.svelte";
   import Close from "carbon-components-svelte/src/icons/Close.svelte";
@@ -86,11 +89,50 @@
   $: ariaLabel = company
     ? `${company} `
     : "" + (uiShellAriaLabel || $$props["aria-label"] || platformName);
+
+  /**
+   * Parse a hex color string (#rgb, #rrggbb, #rrggbbaa) into an {r,g,b} object.
+   * Returns null when the value is not a hex color.
+   */
+  function hexToRgb(color) {
+    if (typeof color !== "string") return null;
+    let hex = color.trim().replace(/^#/, "");
+    if (hex.length === 3 || hex.length === 4) {
+      hex = hex.split("").map((c) => c + c).join("");
+    }
+    if (hex.length !== 6 && hex.length !== 8) return null;
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    if ([r, g, b].some((v) => Number.isNaN(v))) return null;
+    return { r, g, b };
+  }
+
+  /**
+   * Derive a "similar but different" hover tint from the header color:
+   * lighten dark colors and darken light colors so the hover is always visible.
+   */
+  function computeHoverColor(color) {
+    const rgb = hexToRgb(color);
+    if (!rgb) return `color-mix(in srgb, ${color}, #ffffff 13%)`;
+    const { r, g, b } = rgb;
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    const target = luminance < 0.5 ? 255 : 0;
+    const amount = 0.13;
+    const mix = (c) => Math.round(c + (target - c) * amount);
+    return `rgb(${mix(r)}, ${mix(g)}, ${mix(b)})`;
+  }
+
+  $: headerHoverColor = computeHoverColor(headerColor);
+  $: headerStyle =
+    `background-color:${headerColor};` +
+    `--tosti-header-color:${headerColor};` +
+    `--tosti-header-hover:${headerHoverColor};`;
 </script>
 
 <svelte:window bind:innerWidth="{winWidth}" />
 
-<header aria-label="{ariaLabel}" class:bx--header="{true}">
+<header aria-label="{ariaLabel}" class:bx--header="{true}" style={headerStyle}>
   <slot name="skip-to-content" />
   {#if logo !== undefined}
     <img class="logo" src={logo} alt={$_("general.logoAlt")} style="margin-left:{logoMarginLeft};margin-right:{logoMarginRight}" />
@@ -111,9 +153,9 @@
     on:click
   >
     {#if company}
-      <span class:bx--header__name--prefix="{true}">{company}&nbsp;</span>
+      <span class:bx--header__name--prefix="{true}" style={titleColor ? `color:${titleColor};` : undefined}>{company}&nbsp;</span>
     {/if}
-    <span class="header-subtitle">
+    <span class="header-subtitle" style={subTitleColor ? `color:${subTitleColor};` : undefined}>
       <slot name="platform">{platformName}</slot>
     </span>
   </a>
@@ -124,6 +166,24 @@
     .logo {
         max-height: 2.5rem;
         margin: 0.5rem;
+    }
+
+    /* Header utility buttons (language, github) match the header background,
+       with a similar-but-different tint on hover / when active. */
+    :global(.bx--header .bx--header__action:hover),
+    :global(.bx--header .bx--header__action--active),
+    :global(.bx--header .bx--header__action--active:hover) {
+        background-color: var(--tosti-header-hover);
+    }
+
+    /* Search box: collapsed state blends with the header, expanded/active state
+       uses the hover tint. */
+    :global(.bx--header .bx--header__search:not(.bx--header__search--active)) {
+        background-color: var(--tosti-header-color);
+    }
+
+    :global(.bx--header .bx--header__search) {
+        background-color: var(--tosti-header-hover);
     }
 
     :global(.bx--header__name) {

--- a/src/lib/components/header/Header.svelte
+++ b/src/lib/components/header/Header.svelte
@@ -12,12 +12,15 @@
     export let logo: any | undefined = undefined;
     export let logoMarginLeft = "0rem";
     export let logoMarginRight = "0rem";
+    export let headerColor: string = "#161616";
+    export let titleColor: string = "#ffffff";
+    export let subTitleColor: string = "#ffffff";
     export let persistantHamburgerMenu: boolean = false;
     export let isSideNavOpen: boolean = true;
 
 </script>
 
-<CarbonHeader {logo} {logoMarginLeft} {logoMarginRight} {company} {platformName} bind:isSideNavOpen persistentHamburgerMenu={persistantHamburgerMenu}>
+<CarbonHeader {logo} {logoMarginLeft} {logoMarginRight} {company} {platformName} {headerColor} {titleColor} {subTitleColor} bind:isSideNavOpen persistentHamburgerMenu={persistantHamburgerMenu}>
     
     {#if $$slots.headerNav}
         <HeaderNav>

--- a/src/lib/components/header/HeaderUtilityModeSwitcher/HeaderUtilityModeSwitcher.svelte
+++ b/src/lib/components/header/HeaderUtilityModeSwitcher/HeaderUtilityModeSwitcher.svelte
@@ -119,7 +119,7 @@
 		disabled={$disableModeSwitcher}
 	>
 		<span slot="labelA" style="color: white">2D</span>
-		<span slot="labelB" style="color: green">3D</span>
+		<span slot="labelB" style="color: white">3D</span>
 	</Toggle>
 </div>
 

--- a/src/lib/components/header/Language.svelte
+++ b/src/lib/components/header/Language.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { _ } from 'svelte-i18n';
-	import { HeaderAction, HeaderPanelDivider, RadioButtonGroup, RadioButton } from 'carbon-components-svelte';
+	import { HeaderAction, RadioButtonGroup, RadioButton } from 'carbon-components-svelte';
 	import { Translate } from 'carbon-icons-svelte';
 	import { selectedLanguage, languages } from '$lib/i18n/localization';
 
@@ -16,18 +16,18 @@
 				{/each}
 			</RadioButtonGroup>
 		</div>
-
-		<HeaderPanelDivider />
-
-		<div class="wrapper" />
 	</div>
 </HeaderAction>
 
 <style>
+	:global(.bx--header-panel--expanded) {
+		height: auto !important;
+		bottom: auto !important;
+	}
+
 	.wrapper {
 		width: 100%;
 		padding: var(--cds-spacing-05);
-		height: 100%;
 		box-sizing: border-box;
 	}
 

--- a/src/lib/components/tools/MapToolStories/StoryView.svelte
+++ b/src/lib/components/tools/MapToolStories/StoryView.svelte
@@ -651,9 +651,6 @@ async function downloadPDF() {
 				<div class="step-heading heading-04">
 					{step.title}
 				</div>
-				<div class="step-heading-sub heading-03">
-					{$_("tools.stories.description")}
-				</div>
 				<div>
 					{@html step.html}
 				</div>

--- a/static/example.config.json
+++ b/static/example.config.json
@@ -143,6 +143,9 @@
             "duration": 1.50
         },
         "colors": {
+            "header-color": "#161616",
+            "title-color": "#ffffff",
+            "sub-title-color": "#ffffff",
             "ui-background": "#ffffff",
             "interactive-01": "#214170",
             "interactive-02": "#171717",


### PR DESCRIPTION
- Removes story description header (redundant)
- Added color variable options for the viewer header bar (background, title text, subtitle text). Automatically determines the secondary background color for hover, based on the luminance of the chosen color. Defaults to standard values, the colors are optional to include in a config.