### PR TITLE
Enable story from query params on static builds

### DIFF
--- a/src/lib/components/tools/MapToolStories/MapToolStories.svelte
+++ b/src/lib/components/tools/MapToolStories/MapToolStories.svelte
@@ -51,7 +51,7 @@
 			})
 
 			// Directly activate story from searchParams
-			const queriedStory = $page.data.story;
+			const queriedStory = $page.data.story ?? $page.url.searchParams.get("story");
 			if(!queriedStory) return;
 			for (let i = 0; i < stories.length; i++) {
 				if (stories[i].name.toLowerCase() === queriedStory.toLowerCase()) {

--- a/src/routes-static/+layout.ts
+++ b/src/routes-static/+layout.ts
@@ -1,0 +1,3 @@
+export const ssr = false;
+export const csr = true;
+export const prerender = false;

--- a/src/routes-static/+page.ts
+++ b/src/routes-static/+page.ts
@@ -1,0 +1,3 @@
+export const ssr = false;
+export const csr = true;
+export const prerender = false;


### PR DESCRIPTION
Test on static build by creating a static build and running `npm run preview --adapter=static -- --port 4200` and visiting (for example) `http://localhost:4200/?story=Gebiedsanalyse%20Signaalkaarten`