### PR TITLE
Retrieve all layers per data source instead of first one and fixed se…

### DIFF
--- a/src/lib/components/tools/MapToolLayerLibrary/LayerConfigGroup.svelte
+++ b/src/lib/components/tools/MapToolLayerLibrary/LayerConfigGroup.svelte
@@ -18,6 +18,15 @@
     $: totalLayercount = group.totalLayerCount;
     $: enabledLayercount = group.enabledLayerCount;
 
+    $: displayTitle =
+        group.id === "group_background"
+            ? textBaselayers
+            : group.id === "group_uncategorised"
+              ? textNoCategory
+              : group.id === "dataportal"
+                ? $_("tools.layerLibrary.dataportal")
+                : group.title;
+
     function addAllLayers(): void {
         group.addAllLayers();
     }
@@ -41,16 +50,8 @@
             <div class="chevron" class:chevron-rotated={$open}>
                 <ChevronRight />
             </div>
-            <div class="group-title">
-                {#if group.id === "group_background"}
-                    {textBaselayers}
-                {:else if group.id === "group_uncategorised"}
-                    {textNoCategory}
-                {:else if group.id === "dataportal"}
-                    {$_('tools.layerLibrary.dataportal')}
-                {:else}
-                    {group.title}
-                {/if}
+            <div class="group-title" title={displayTitle}>
+                {displayTitle}
             </div>
             {#if group.toolGroup}
                 <span class="tool-group-icon" title={$_('tools.layerLibrary.toolGroupTooltip', { values: { tool: $_(group.toolGroup.label) } })}>
@@ -132,6 +133,7 @@
         cursor: pointer;
         align-items: center;
         align-content: center;
+        min-width: 0;
     }
 
     .group:hover {
@@ -167,10 +169,12 @@
 
     .group-title {
         margin-left: var(--cds-spacing-02);
-        display: flex;
-        align-items: center;
         padding-top: 2px;
         flex-grow: 1;
+        min-width: 0;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
     }
 
     .group-content {

--- a/src/lib/components/tools/MapToolLayerLibrary/LibraryLayerInfo.svelte
+++ b/src/lib/components/tools/MapToolLayerLibrary/LibraryLayerInfo.svelte
@@ -12,6 +12,7 @@
 
     export let layerConfig: Writable<LayerConfig>;
     export let path: string = "";
+    export let connector: Record<string, string> | undefined = undefined;
 
     let contentIndex = 0;
     let copied = false;
@@ -32,10 +33,6 @@
     $: dateCreatedFormatted = formatDate(config.dateCreated, $locale);
     $: dateRevisionFormatted = formatDate(config.dateRevision, $locale);
     $: settings = syntaxHighlight(getJsonLayerConfig(config));
-
-    layerConfig.subscribe(() => {
-        contentIndex = 0;
-    });
 
     const standardMetadata = new Metadata();
     $: { standardMetadata.parseMetadataUrl(metadataUrl) }
@@ -149,7 +146,21 @@
 </script>
 
 <div class="wrapper">
-    <div class="label-01">{path}</div>
+    <div class="breadcrumbs">
+        {#if connector && connector.type && connector.url}
+            <a
+                class="connector-tag"
+                href={connector.url}
+                title={$_("general.goTo") + " " + connector.type}
+                target="_blank"
+            >
+                <Tag type="green" size="sm" interactive={true}>
+                    {connector.type}
+                </Tag>
+            </a>
+        {/if}
+        <div class="label-01" title={path}>{path}</div>
+    </div>
     <div class="header">
         
         <div class="heading-03">{config.title}</div>
@@ -320,6 +331,19 @@
         white-space: pre-line;
     }
 
+    .breadcrumbs {
+        display: flex;
+        align-items: center;
+        gap: var(--cds-spacing-01);
+    }
+
+    .breadcrumbs .label-01 {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
     .header {
         width: 100%;
         padding: var(--cds-spacing-03) 0rem var(--cds-spacing-03) 0px;
@@ -417,6 +441,26 @@
 
     .layer-type {
         margin-left: -4px;
+    }
+
+    .connector-tag {
+        display: inline-block;
+        text-decoration: none;
+        flex-shrink: 0;
+    }
+
+    .connector-tag :global(.bx--tag) {
+        max-width: none;
+        margin-left: 0;
+    }
+
+    .connector-tag :global(.bx--tag__label) {
+        cursor: pointer;
+        word-break: normal;
+        white-space: nowrap;
+        max-width: none;
+        overflow: visible;
+        text-overflow: clip;
     }
 
     :global(.block p a) {

--- a/src/lib/components/tools/MapToolLayerLibrary/MapToolLayerLibraryView.svelte
+++ b/src/lib/components/tools/MapToolLayerLibrary/MapToolLayerLibraryView.svelte
@@ -28,6 +28,7 @@
     const loadingConnectors = library.loadingConnectors;
     const selectedLayerConfig = library.selectedLayerConfig;
     $: path = $selectedLayerConfig ? findPath($selectedLayerConfig.groupId, "") : "";
+    $: connector = $selectedLayerConfig ? findConnector($selectedLayerConfig.groupId) : undefined;
 
     const selectedCustomLayer = writable<CustomLayerConfigTracker | undefined>(undefined);
     const mylayers = $groups.find((g) => { if(g.id === "myData") return g })?.layerConfigs;
@@ -74,9 +75,7 @@
             return;
         }
 
-        if (searchableList.length === 0) {
-            searchableList = getFlatList();
-        }
+        searchableList = getFlatList();
 
         let results = new Array<LayerConfig>();
         const fuzzy = fuzzysort.go(searchStr, searchableList, { key: "key" });
@@ -133,6 +132,9 @@
     selectedTagIDs.subscribe(() => {
         searchAndFilter();
     });
+    loadingConnectors.subscribe(() => {
+        searchAndFilter();
+    });
 
     function resetFilter(): void {
         selectedTagIDs.set([]);
@@ -174,6 +176,17 @@
         }
 
         return path;
+    }
+
+    function findConnector(groupId: string): Record<string, string> | undefined {
+        let g = library.findGroup(groupId);
+        while (g) {
+            if (g.connector && g.connector.type && g.connector.url) {
+                return g.connector;
+            }
+            g = g.parentId ? library.findGroup(g.parentId) : undefined;
+        }
+        return undefined;
     }
 
     function getGroupTitle(g: LayerConfigGroup): string {
@@ -344,7 +357,7 @@
             <div class="content">
                 {#if contentIndex === 0}
                     {#if $selectedLayerConfig}
-                        <LibraryLayerInfo layerConfig={selectedLayerConfig} {path} />
+                        <LibraryLayerInfo layerConfig={selectedLayerConfig} {path} {connector} />
                     {:else}
                         <div>
                             <InlineNotification
@@ -407,6 +420,13 @@
         padding: var(--cds-spacing-05) var(--cds-spacing-05) 0 var(--cds-spacing-05);
         display: flex;
         flex-direction: column;
+    }
+
+    @media (min-width: 1920px) {
+        .menu {
+            flex-basis: 40%;
+            max-width: 45%;
+        }
     }
 
     .switcher {

--- a/src/lib/components/tools/MapToolLayerManager/MapToolLayerManager.svelte
+++ b/src/lib/components/tools/MapToolLayerManager/MapToolLayerManager.svelte
@@ -70,6 +70,13 @@
         return groupIds
     }
 
+    // A group is relevant when it (or any descendant group) contains a present layer,
+    // so intermediate groups on the path to a nested layer are not pruned.
+    function groupSubtreeHasLayers(group: LayerConfigGroup): boolean {
+        if (groupsWithLayers.includes(group.id)) return true;
+        return get(group.childGroups).some(groupSubtreeHasLayers);
+    }
+
     function buildGroupsRecursive(layerConfigGroups: Array<LayerConfigGroup>) {
         let groups = Array<LayerManagerGroup>();
         // copy library groups to layer groups
@@ -85,7 +92,7 @@
                 layerManagerGroup.addLayer(layer)
             }
             // add childgroups
-            const childConfigGroups = get(group.childGroups).filter(g => groupsWithLayers.includes(g.id))
+            const childConfigGroups = get(group.childGroups).filter(groupSubtreeHasLayers)
             const childLayerGroups = buildGroupsRecursive(childConfigGroups)
             for (let i = 0; i < childLayerGroups.length; i++) {
                 const childLayerGroup = childLayerGroups[i];

--- a/src/lib/map-core/library-connectors/geonetwork/geonetwork-connector.ts
+++ b/src/lib/map-core/library-connectors/geonetwork/geonetwork-connector.ts
@@ -4,6 +4,7 @@ import type { LibraryConnector } from "../library-connector";
 import { LibraryConnectorData } from "../library-connector-data";
 import { get } from "svelte/store";
 import type { GeoNetworkConnectorSettings } from "./geonetwork-connector-settings";
+import { fetchCapabilitiesLayers } from "$lib/components/tools/MapToolLayerLibrary/CustomLayers/capabilities";
 
 
 export class GeoNetworkConnector implements LibraryConnector {
@@ -25,13 +26,16 @@ export class GeoNetworkConnector implements LibraryConnector {
             try {  
                 const groups = await this.getAllGroups();
                 const layerConfigs = new Array<LayerConfig>();
+                const recordGroups = new Array<LayerConfigGroup>();
 
                 for (let i = 0; i < groups.length; i++) {
-                    const configs = await this.getLayerConfigs(groups[i]);
+                    if (groups[i].id === "dataportal") continue;  // skip fake parent
+                    const { configs, subgroups } = await this.getLayerConfigs(groups[i]);
                     layerConfigs.push(...configs);
+                    recordGroups.push(...subgroups);
                 }
 
-                this.data = new LibraryConnectorData(groups, layerConfigs);
+                this.data = new LibraryConnectorData([...groups, ...recordGroups], layerConfigs);
             } catch (error) {
                 throw error;
             }
@@ -62,24 +66,38 @@ export class GeoNetworkConnector implements LibraryConnector {
     /**
      * Request all packages and resources from CKAN
      * @param type Either 'organization', 'group' or 'dataset'
-     * @returns List of LayerConfigs parsed from CKAN packages
+     * @returns The parsed LayerConfigs and any per-record subgroups
      */
-    private async getLayerConfigs(group: LayerConfigGroup): Promise<Array<LayerConfig>> {
-        try {
-            const suffix = `&topicCat=${group.id}&resultType=details&buildSummary=false&fast=index`;
-            const request = `${this.settings.url}/${this.endpointSearch}?_content_type=json&${suffix}&from=1&to=1000`;
-            const result = await this.get(request);
+    private async getLayerConfigs(group: LayerConfigGroup): Promise<{ configs: Array<LayerConfig>, subgroups: Array<LayerConfigGroup> }> {
+        const allConfigs = new Array<LayerConfig>();
+        const allSubgroups = new Array<LayerConfigGroup>();
+        const pageSize = 100;
+        const maxPages = 1000; // safety guard against an API that ignores paging
+        let from = 1;
 
-            if (result) {
-                return this.geoNetworkLayersToLayerConfigs(result);
-            } else {
-                console.log("GeoNetwork Connector: Get packages request unsuccessful");
-                setTimeout(() => this.getLayerConfigs(group), 2000); // Re-try after 2 seconds
+        try {
+            for (let page = 0; page < maxPages; page++) {
+                const to = from + pageSize - 1;
+                const suffix = `&topicCat=${group.id}&resultType=details&buildSummary=false&fast=index`;
+                const request = `${this.settings.url}/${this.endpointSearch}?_content_type=json&${suffix}&from=${from}&to=${to}`;
+                const result = await this.get(request);
+
+                if (!result?.metadata) break;
+
+                const { configs, subgroups } = await this.geoNetworkLayersToLayerConfigs(result, group.id);
+                allConfigs.push(...configs);
+                allSubgroups.push(...subgroups);
+
+                const returned = Array.isArray(result.metadata) ? result.metadata.length : 1;
+                if (returned < pageSize) break;
+
+                from += pageSize;
             }
         } catch (error) {
             throw error;
         }
-        return [];
+
+        return { configs: allConfigs, subgroups: allSubgroups };
     }
 
 
@@ -119,51 +137,64 @@ export class GeoNetworkConnector implements LibraryConnector {
         return groups;
     }
 
-    private geoNetworkLayersToLayerConfigs(result: any): Array<LayerConfig> {
+    private async geoNetworkLayersToLayerConfigs(result: any, groupId: string): Promise<{ configs: Array<LayerConfig>, subgroups: Array<LayerConfigGroup> }> {
         const configs = new Array<LayerConfig>();
+        const subgroups = new Array<LayerConfigGroup>();
 
         if(!result?.metadata) {
-            return configs;
+            return { configs, subgroups };
         }
 
-        const layers = result.metadata;
+        const layers = Array.isArray(result.metadata) ? result.metadata : [result.metadata];
 
-        for(let i = 0; i < layers.length; i++) {
-            const l = layers[i];
-            let groupId = l.topicCat || 'dataportal'; // Default to dataportal if no group is found
+        // Resolve settings per record first, so WMS capabilities can be fetched
+        // once per unique endpoint (cached) instead of once per layer.
+        const parsed: Array<{ l: any; settingsList: Array<any> }> = layers
+            .map((l: any) => ({ l, settingsList: this.getSettings(l.link) }))
+            .filter((entry: { l: any; settingsList: Array<any> }) => entry.settingsList.length > 0);
 
-            // If groupId is an array, use the first element
-            if (Array.isArray(groupId)) {
-                groupId = groupId[0];
+        const urls: Array<string> = [];
+        for (const entry of parsed) {
+            for (const s of entry.settingsList) urls.push(s.url);
+        }
+        const titleMap = await this.getWmsTitleMap(urls);
+
+        for (const { l, settingsList } of parsed) {
+            const multipleLayers = settingsList.length > 1;
+
+            // Records exposing multiple WMS layers are nested under a subgroup named
+            // after the record, so the near-identical child layers are easier to tell apart.
+            const childGroupId = multipleLayers ? l.identifier : groupId;
+            if (multipleLayers) {
+                subgroups.push(new LayerConfigGroup(l.identifier, l.title, groupId));
             }
-            
-            const layerSettings = this.getSettings(l.link);
-            if (Object.keys(layerSettings).length === 0) {
-                continue;
-            }
 
-            const lc = new LayerConfig({
-                id: l.identifier,
-                type: "wms",
-                title: l.title,
-                description: l.abstract,
-                groupId: groupId,
-                imageUrl: this.getImageUrl(l.image),
-                attribution: l.lineage,
-                isBackground: false,
-                legendUrl: undefined,
-                defaultAddToManager: false,
-                defaultOn: false,
-                metadata: undefined,
-                metadataUrl: '',
-                metadataLink: this.settings.url + this.linkFormat.replace('{uuid}', l['geonet:info'].uuid),
-                dateCreated: l.publicationDate ?? l.creationDate ?? "",
-                dateRevision: l.revisionDate ?? "",
-                settings: layerSettings,
-                cameraPosition: undefined,
-                tags: undefined
-            });                
-            configs.push(lc);
+            for (let j = 0; j < settingsList.length; j++) {
+                const layerSettings = settingsList[j];
+                const wmsTitle = titleMap.get(`${layerSettings.url}::${layerSettings.featureName}`) ?? layerSettings.featureName;
+                const lc = new LayerConfig({
+                    id: multipleLayers ? `${l.identifier}__${layerSettings.featureName}` : l.identifier,
+                    type: "wms",
+                    title: multipleLayers ? wmsTitle : l.title,
+                    description: l.abstract,
+                    groupId: childGroupId,
+                    imageUrl: this.getImageUrl(l.image),
+                    attribution: l.lineage,
+                    isBackground: false,
+                    legendUrl: undefined,
+                    defaultAddToManager: false,
+                    defaultOn: false,
+                    metadata: undefined,
+                    metadataUrl: '',
+                    metadataLink: this.settings.url + this.linkFormat.replace('{uuid}', l['geonet:info'].uuid),
+                    dateCreated: l.publicationDate ?? l.creationDate ?? "",
+                    dateRevision: l.revisionDate ?? "",
+                    settings: layerSettings,
+                    cameraPosition: undefined,
+                    tags: undefined
+                });
+                configs.push(lc);
+            }
         }
 
         if(this.debug) {
@@ -172,7 +203,28 @@ export class GeoNetworkConnector implements LibraryConnector {
             }
         }
 
-        return configs;
+        return { configs, subgroups };
+    }
+
+    /**
+     * Fetches WMS GetCapabilities once per unique endpoint (deduplicated and cached by
+     * the capabilities helper) and builds a lookup of `${url}::${featureName}` to the
+     * human-readable layer title. Endpoints are fetched in parallel.
+     */
+    private async getWmsTitleMap(urls: Array<string>): Promise<Map<string, string>> {
+        const titleMap = new Map<string, string>();
+        const uniqueUrls = Array.from(new Set(urls));
+        await Promise.all(uniqueUrls.map(async (url) => {
+            try {
+                const capabilitiesLayers = await fetchCapabilitiesLayers(url, "wms");
+                for (const layer of capabilitiesLayers) {
+                    titleMap.set(`${url}::${layer.id}`, layer.text);
+                }
+            } catch (error) {
+                console.error(error);
+            }
+        }));
+        return titleMap;
     }
 
     private getValueFromMetadata(key: string, metadata: Array<{ key: string, value: any}>) : string | undefined {
@@ -192,28 +244,29 @@ export class GeoNetworkConnector implements LibraryConnector {
         return imageUrl?.split('|')[1];
     }
 
-    private getSettings(link: Array<string> | undefined): Object {
+    private getSettings(link: Array<string> | undefined): Array<any> {
+        const wmslinks: Array<any> = [];
         try {
             if (!link) {
-                return {};
+                return wmslinks;
             }
             const links = Array.isArray(link) ? link : [link];
             for (let i = 0; i < links.length; i++) {
                 let l = links[i];
                 if (l.includes('OGC:WMS')) {
                     let l_split = l.split('|');
-                    return {
+                    wmslinks.push({
                         url: l_split[2].split('?')[0],
                         type: 'wms',
                         featureName: l_split[0],
                         contenttype: 'image/png'
-                    }
+                    });
                 }
             }
         } catch (error) {
             console.error(error);
         }
-        return {}
+        return wmslinks;
     }
 
     /**


### PR DESCRIPTION
## Summary

Replaces PR 384.

Improvements to the GeoNetwork data-portal connector and the layer library UI. GeoNetwork records that expose multiple WMS layers now surface **all** of their layers (previously only the first was shown), and several search/UI issues in the layer library were fixed.

## GeoNetwork connector (`geonetwork-connector.ts`)

- **Retrieve all WMS layers per record** instead of only the first one. `getSettings()` now returns an array of every `OGC:WMS` link found on a record rather than the first match.
- **Auto-group multi-layer records:** records exposing multiple WMS layers are now nested under a subgroup named after the record, so near-identical child layers are easier to tell apart.
- **Human-readable layer titles:** WMS `GetCapabilities` is fetched once per unique endpoint (deduplicated, cached, fetched in parallel) to resolve friendly layer titles for the nested layers.
- **Paginated fetching:** records are now retrieved in pages of 100 (with a safety guard against endpoints that ignore paging) instead of a single `from=1&to=1000` request.
- Skip the fake `dataportal` parent group when building configs.
- Handle GeoNetwork `metadata` responses that return a single object as well as an array.

## Layer library search & UI

- **Fixed search bar:** the searchable list is now always rebuilt from the current layers, and search/filter re-runs when connectors finish loading — so layers that load asynchronously are now findable.
- **Connector tag / breadcrumb:** the layer info panel now shows a clickable green tag linking to the source connector (type + URL), resolved by walking up the group tree.
- **Wider library panel** on large screens (≥1920px).
- Removed the reset of the active content tab when the selected layer changes.

## Layer library styling

- **Group titles** now truncate with an ellipsis instead of overflowing (`LayerConfigGroup.svelte`).
- **Breadcrumb path** truncates with an ellipsis in the layer info panel.

## Layer manager (`MapToolLayerManager.svelte`)

- **Fixed pruning of intermediate groups:** a group is now kept if it *or any descendant* contains a layer (`groupSubtreeHasLayers`), so parent groups on the path to a nested layer are no longer incorrectly removed.