### PR TITLE
Stories: skip layer hide/restore when a story never changes layers

### DIFF
--- a/src/lib/components/map-cesium/MapToolStories/StoryView.svelte
+++ b/src/lib/components/map-cesium/MapToolStories/StoryView.svelte
@@ -131,6 +131,10 @@
 		});
 	});
 
+	// Whether any step in this story actually adds/changes layers. If not, there is no need to
+	// hide/restore the existing layers on open/close, which avoids an unnecessary map reload.
+	const hasStoryLayers = flattenedSteps.some(({ step }) => step.layers && step.layers.length > 0);
+
 
 	onMount(() => {
 		if (story.force2DMode) {
@@ -152,7 +156,7 @@
 		startTerrain = get(map.options.selectedTerrainProvider);
 
 		setStartVisibleLayers();
-		hideAllLayers();
+		if (hasStoryLayers) hideAllLayers();
 
 		// Return to step where user left
 		currentPage.set(savedStepNumber);
@@ -355,8 +359,10 @@
 	}
 
 	function resetToStart(): void {
-		removeAllLayers();
-		restoreStartLayerState();
+		if (hasStoryLayers) {
+			removeAllLayers();
+			restoreStartLayerState();
+		}
 		map.options.globeOpacity.set(startGlobeOpacity);
 		map.options.selectedTerrainProvider.set(startTerrain);
 		//map.zoomTo(startCameraLocation);


### PR DESCRIPTION
Some stories only show info/HTML content and never add or hide any layers (all steps have an empty 'layers' array). In that case, hideAllLayers() was still called on open and removeAllLayers()/ restoreStartLayerState() on close, which unnecessarily hid and then re-showed the layers that were visible before opening the story. Re-showing previously hidden layers can trigger a reload of cached tiles, causing a visible 'reset' of the map on close even though the story never touched the map.

This adds a hasStoryLayers check so the hide/restore logic is skipped entirely when no step in the story defines any layers.