### PR TITLE
Add story camera/opacity controls and camera collision config:

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ Tool where the user can change settings of the Cesium viewer. Settings can be us
 |pointCloudEDLStrength|Eye dome lighting strength (apparent contrast)|1|number|
 |pointCloudEDLRadius|Thickness of contours from eye dome lighting|1|number|
 |globeOpacity|Opacity percentage of the globe|100|number|
+|enableCollisionDetection|Prevent the camera from moving below the terrain/surface. Set to `true` to prevent going subsurface|false|boolean|
 |terrainProviders|Array of terrain providers, first in list is activated by default, leave out URL to create empty provider (see example below)|-|Terrain Provider|
 
 
@@ -800,6 +801,7 @@ Tool where the user can change settings of the Cesium viewer. Settings can be us
 		"skyAtmosphere": true,
 		"fog": true,
 		"highDynamicRange": false,
+		"enableCollisionDetection": false,
 		"pointCloudAttenuationMaximum": 2,
 		"terrainProviders": [
           {
@@ -1008,7 +1010,7 @@ Measuring tool accessible through the toolbar, with this tool the user can add 3
 
 #### stories
 
-Tool for storymapping. Create and show multiple stories in the viewer. Each story can contain multiple chapters with steps which the user can click through. Each chapter has an id, title, button text (shorthand for longer titles) and steps. Each step has a title and description (HTML), a fly-to location, and a set of layers with their settings (id, style, opacity). A story can be opened directly in the viewer through the 'story' search parameter, for example: "https://some-site.nl/?story=mystoryname".
+Tool for storymapping. Create and show multiple stories in the viewer. Each story can contain multiple chapters with steps which the user can click through. Each chapter has an id, title, button text (shorthand for longer titles) and steps. Each step has a title and description (HTML), a fly-to location, and a set of layers with their settings (id, style, opacity, showOpacitySlider). A story can be opened directly in the viewer through the 'story' search parameter, for example: "https://some-site.nl/?story=mystoryname".
 
 |value||description|type|
 |-|-|-|-|
@@ -1017,12 +1019,21 @@ Tool for storymapping. Create and show multiple stories in the viewer. Each stor
 |stories|name|The name of the story|string|
 ||description|A short description to describe the story|string|
 ||width|The width of the story menu|string|
-||force2DMode|Sets the camera to 2D mode and prevents users from switching camera mode while the story is open|boolean|
+||forceCameraMode|Forces the camera into a fixed mode while the story is open and prevents users from switching camera mode. Accepts `"2D"` or `"3D"`. On opening the story the camera switches to the given mode if needed; on closing it reverts to the previous mode if it was changed|string|
 ||staticCamera|Keeps camera location the same after drawing and between steps|boolean|
 ||requestPolygonArea|Adds a polygon drawing tool that requests data in each story step from a WMS layer if a WCS layer with an identical name exists. Define whether the tool is enabled and what API should be used (if enabled)|object|
 ||baseLayerId|ID of a base layer that can be toggled on or off and can be seen in each story step|string|
 ||chapters|Structure of storysteps within chapters. Each chapter has a chapter id and a list of steps. See the example below|object|
 ||chapterGroups|Groups the chapter ids refer to|object|
+
+Each layer within a step's `layers` array supports these settings:
+
+|value|description|default|type|
+|-|-|-|-|
+|id|ID of the layer to add in this step|-|string|
+|opacity|Initial opacity percentage of the layer|100|number|
+|style|Style/theme to apply to the layer|-|string|
+|showOpacitySlider|Whether the transparency slider is shown for this layer in the story step|true|boolean|
 
 ```json
 
@@ -1037,7 +1048,7 @@ Tool for storymapping. Create and show multiple stories in the viewer. Each stor
 				"name": "My Story",
 				"description": "Description of my story",
 				"width": "600px",
-				"force2DMode": false,
+				"forceCameraMode": "2D",
 				"staticCamera": false,
 				"requestPolygonArea": {
 					"enabled": false,
@@ -1068,11 +1079,11 @@ Tool for storymapping. Create and show multiple stories in the viewer. Each stor
 									},
 									{
 										"id": "19747667-ddb2-4162-99f6-a37d5aaa15ea",
-										"style": "Bouwjaar"
+										"style": "Bouwjaar",
+										"showOpacitySlider": false
 									}
 									//etc. You can add as many layers as you want per step
-								]
-							},
+								]							},
 							//etc. You can add as many steps as you want per chapter
 						]
 					},

--- a/src/lib/components/tools/MapToolStories/MapToolStories.svelte
+++ b/src/lib/components/tools/MapToolStories/MapToolStories.svelte
@@ -91,7 +91,7 @@
 				const storyName: string = story.name;
 				const storyDescription: string = story.description;
 				const storyWidth: string = story.width;
-				const storyForce2DMode: boolean = story.force2DMode ?? false;
+				const storyForceCameraMode: "2D" | "3D" | undefined = story.forceCameraMode ?? undefined;
 				const storyStaticCamera: boolean = story.staticCamera ?? false;
 				const storyRequestPolygonArea:boolean = story.requestPolygonArea.enabled ?? false;
 				const storyStatisticsApi: string | undefined = story.requestPolygonArea.statisticsApi ?? undefined;
@@ -125,9 +125,10 @@
 						const storyLayers = new Array<StoryLayer>();
 						for (let l = 0; l < step.layers.length; l++) {
 							const opacity = step.layers[l].opacity ?? 100;
+							const showOpacitySlider = step.layers[l].showOpacitySlider ?? true;
 							const {url, featureName} = getUrlAndFeatureNameForLayer(step.layers[l].id);
 							storyLayers.push(
-								new StoryLayer(step.layers[l].id, opacity, step.layers[l].style, url, featureName)
+								new StoryLayer(step.layers[l].id, opacity, step.layers[l].style, url, featureName, showOpacitySlider)
 							);
 							const layerLegendInfo = {
 								generalLegendText: step.layers[l].generalLegendText,
@@ -140,7 +141,7 @@
 					}
 					storyChapters.push(new StoryChapter(chapter.id, chapterTitle, chapterButtonText, storySteps));
 				}
-				loadedStories.push(new Story(storyName, storyDescription, storyChapters, storyWidth, storyForce2DMode, storyStaticCamera, storyRequestPolygonArea, storyStatisticsApi));
+				loadedStories.push(new Story(storyName, storyDescription, storyChapters, storyWidth, storyForceCameraMode, storyStaticCamera, storyRequestPolygonArea, storyStatisticsApi));
 			}
 		}
 		stories = loadedStories;

--- a/src/lib/components/tools/MapToolStories/Story.ts
+++ b/src/lib/components/tools/MapToolStories/Story.ts
@@ -7,7 +7,7 @@ export class Story {
     public description: string;
     public storyChapters: Array<StoryChapter>;
     public width: string | undefined;
-    public force2DMode: boolean | undefined;
+    public forceCameraMode: "2D" | "3D" | undefined;
     public staticCamera: boolean | undefined;
     public requestPolygonArea: boolean | undefined;
     public statisticsApi: string | undefined;
@@ -16,7 +16,7 @@ export class Story {
                 description: string, 
                 storyChapters: Array<StoryChapter>, 
                 width: string | undefined = undefined, 
-                force2DMode: boolean | undefined, 
+                forceCameraMode: "2D" | "3D" | undefined, 
                 staticCamera: boolean | undefined,
                 requestPolygonArea: boolean | undefined,
                 statisticsApi: string | undefined) {
@@ -24,7 +24,7 @@ export class Story {
         this.description = description;
         this.storyChapters = storyChapters;
         this.width = width;
-        this.force2DMode = force2DMode;
+        this.forceCameraMode = forceCameraMode;
         this.staticCamera = staticCamera;
         this.requestPolygonArea = requestPolygonArea;
         this.statisticsApi = statisticsApi;

--- a/src/lib/components/tools/MapToolStories/StoryLayer.ts
+++ b/src/lib/components/tools/MapToolStories/StoryLayer.ts
@@ -5,12 +5,14 @@ export class StoryLayer {
     public opacity: number;
     public url: string | undefined;
     public featureName: string | undefined;
+    public showOpacitySlider: boolean;
 
-    constructor(id: string, opacity: number, style: any = undefined, url: string | undefined, featureName: string | undefined) {
+    constructor(id: string, opacity: number, style: any = undefined, url: string | undefined, featureName: string | undefined, showOpacitySlider: boolean = true) {
         this.id = id;
         this.opacity = opacity;
         this.style = style;
         this.url = url; // URL for WCS request, NOT for fetching the WMS layer
         this.featureName = featureName;
+        this.showOpacitySlider = showOpacitySlider;
     }
 }

--- a/src/lib/components/tools/MapToolStories/StoryView.svelte
+++ b/src/lib/components/tools/MapToolStories/StoryView.svelte
@@ -4,7 +4,7 @@
 	import * as Cesium from "cesium";
 	import { writable, get, type Writable } from "svelte/store";
 	import { Button, Tag, SliderSkeleton } from "carbon-components-svelte";
-	import { Exit, ChevronDown, ChevronUp, ChoroplethMap } from "carbon-icons-svelte";
+	import { Return, ChevronDown, ChevronUp, ChoroplethMap } from "carbon-icons-svelte";
 	import "@carbon/charts-svelte/styles.css";
 	import { jsPDF } from 'jspdf';
 
@@ -61,6 +61,7 @@
 	let startVisibleLayers = new Array<string>();
 	let startGlobeOpacity: number;
 	let startTerrain: {title: string, url: string, vertexNormals: boolean};
+	let startUse3DMode: boolean = get(map.options.use3DMode);
 
 	let polygonArea: number = 0;
 	let hasDrawnPolygon: Writable<boolean> = writable(false);
@@ -135,9 +136,10 @@
 
 
 	onMount(() => {
-		if (story.force2DMode) {
+		if (story.forceCameraMode) {
+			const targetMode = story.forceCameraMode === "3D";
 			map.options.disableModeSwitcher.set(true);
-			if (get(map.options.use3DMode)) map.options.use3DMode.set(false);
+			if (get(map.options.use3DMode) !== targetMode) map.options.use3DMode.set(targetMode);
 		}
 
 		startCameraLocation = cesiumMap.getPosition();
@@ -171,7 +173,11 @@
 
 
 	onDestroy(() => {
-		if (story.force2DMode) map.options.disableModeSwitcher.set(false);
+		if (story.forceCameraMode) {
+			map.options.disableModeSwitcher.set(false);
+			const targetMode = story.forceCameraMode === "3D";
+			if (targetMode !== startUse3DMode) map.options.use3DMode.set(startUse3DMode);
+		}
 
 		map.autoCheckBackground = startAutocheckBackground;
 		resizeObserver?.disconnect();
@@ -225,8 +231,9 @@
 
 
 	currentPage.subscribe((page) => {
-		if (story.force2DMode) {
-			if (get(map.options.use3DMode)) map.options.use3DMode.set(false);
+		if (story.forceCameraMode) {
+			const targetMode = story.forceCameraMode === "3D";
+			if (get(map.options.use3DMode) !== targetMode) map.options.use3DMode.set(targetMode);
 		} // Set this again because apparently OnMount is slower than a subscribe :/
 		const index = page - 1;
 
@@ -601,7 +608,7 @@ async function downloadPDF() {
 				iconDescription={textBack}
 				tooltipPosition="bottom"
 				tooltipAlignment="end"
-				icon={Exit}
+				icon={Return}
 				on:click={backToOverview} 
 			/>
 		</div>
@@ -727,18 +734,20 @@ async function downloadPDF() {
 				</div>
 				<div class="opacity-controls">
 					{#each step.layers ?? [] as layer}
-						{#await (async () => {
-							while (!getAdded(layer.id.toString())) {
-								await new Promise(r => setTimeout(r, 100));
-							}
-							return getAdded(layer.id.toString());
-						})() then addedLayer}
-							{#if addedLayer}
-								<StoryOpacitySlider layer={addedLayer} />
-							{/if}
-						{:catch}
-							<SliderSkeleton hideLabel />
-						{/await}
+						{#if layer.showOpacitySlider}
+							{#await (async () => {
+								while (!getAdded(layer.id.toString())) {
+									await new Promise(r => setTimeout(r, 100));
+								}
+								return getAdded(layer.id.toString());
+							})() then addedLayer}
+								{#if addedLayer}
+									<StoryOpacitySlider layer={addedLayer} />
+								{/if}
+							{:catch}
+								<SliderSkeleton hideLabel />
+							{/await}
+						{/if}
 					{/each}
 				</div>
 				<div class="tag">

--- a/src/lib/components/tools/MapToolZonalStatistics/zonal-statistics-controller.ts
+++ b/src/lib/components/tools/MapToolZonalStatistics/zonal-statistics-controller.ts
@@ -1,0 +1,879 @@
+import { get, writable, type Unsubscriber, type Writable } from "svelte/store";
+import * as Cesium from "cesium";
+import * as turf from "@turf/turf";
+
+import type { Map as CesiumMap } from "$lib/map-cesium/map";
+import type { MouseLocation } from "$lib/map-core/mouse-location";
+import type { GeoJsonLayer } from "$lib/map-cesium/layers/geojson-layer";
+import type { ZonalStatisticsSettings } from "./zonal-config";
+
+/**
+ * A single selected zone (e.g. one PC6 area).
+ */
+export interface SelectedZone {
+	/** Stable identifier of the zone (its code, e.g. the PC6 code). */
+	code: string;
+}
+
+/** One row of the zone table (one configured data layer). */
+export interface ZoneTableRow {
+	/** Config id of the data layer. */
+	layerId: string;
+	/** Human readable title shown as the row label. */
+	title: string;
+	/** zone code -> per-column display values (aligned to `settings.columns`). */
+	values: Record<string, Array<string | undefined>>;
+	/** zone code -> per-column tooltip texts (aligned to `settings.columns`). */
+	tooltips: Record<string, Array<string | undefined>>;
+}
+
+/** The full zone table model consumed by the view. */
+export interface ZoneTable {
+	/** Selected zone codes, in selection order (the table columns groups). */
+	zones: Array<string>;
+	/** One row per configured data layer. */
+	rows: Array<ZoneTableRow>;
+}
+
+/**
+ * One flattened export row for the zone table.
+ * Each selected zone and data-layer row combination becomes one export row.
+ */
+export interface ZonalStatisticsExportRow {
+	zoneCode: string;
+	layerTitle: string;
+	/** Display value per configured column, aligned to `settings.columns`. */
+	values: Array<string>;
+	/** Tooltip/description per configured column, aligned to `settings.columns`. */
+	tooltips: Array<string>;
+}
+
+export interface ResolvedDataLayer {
+	layerId: string;
+	title: string;
+	layer: GeoJsonLayer;
+}
+
+/** Per-instance pick id carried by each fill polygon part (all parts of a zone share a code). */
+interface ZoneInstanceId {
+	code: string;
+}
+
+/** Rendering + bookkeeping for one layer's batched fill primitive. */
+interface FillLayerRender {
+	layer: GeoJsonLayer;
+	primitive: Cesium.Primitive;
+	/** zone code -> the instance ids of its polygon parts. */
+	idsByCode: Map<string, Array<ZoneInstanceId>>;
+	/** instance id -> its source entity (to re-read colour on restyle). */
+	entityById: Map<ZoneInstanceId, Cesium.Entity>;
+	/** instance id -> current base label colour. */
+	baseColor: Map<ZoneInstanceId, Cesium.Color>;
+}
+
+/** Combined area of the selected zones that carry one categorical value, in m². */
+export interface CategoryArea {
+	/** The categorical (styled) value. */
+	value: string;
+	/** Combined area of the selected zones holding this value, in square metres. */
+	areaSqMeters: number;
+}
+
+/** Basic descriptive statistics for a numeric column across the selected zones. */
+export interface NumericStat {
+	min: number;
+	max: number;
+	mean: number;
+	/** Number of selected zones that had a numeric value for this column. */
+	count: number;
+}
+
+/** Computed summary for one configured column (categorical area breakdown OR numeric stats). */
+export interface SummaryColumn {
+	/** Index into `settings.columns`. */
+	columnIndex: number;
+	/** Whether the column is styled (categorical). */
+	styled: boolean;
+	/** Area per category value (styled columns only), largest first. */
+	categories?: Array<CategoryArea>;
+	/** Descriptive statistics (non-styled numeric columns only). */
+	numeric?: NumericStat;
+}
+
+/** One summary row (one configured data layer) with a result per configured column. */
+export interface SummaryRow {
+	layerId: string;
+	title: string;
+	columns: Array<SummaryColumn>;
+}
+
+/** The computed summary aggregated across all selected zones. */
+export interface ZonalSummary {
+	/** Number of selected zones. */
+	zoneCount: number;
+	/** Combined area of all selected zones, in square metres. */
+	totalAreaSqMeters: number;
+	/** One row per configured data layer. */
+	rows: Array<SummaryRow>;
+}
+
+/**
+ * Owns all non-UI logic for the Zonal Statistics tool: resolving the
+ * configured zone + data layers, ensuring their data is loaded, handling map
+ * clicks to (de)select zones, highlighting the selection, and building the
+ * zone table. UI components subscribe to the exposed stores.
+ */
+export class ZonalStatisticsController {
+	// State colours layered over each zone's base label fill. Selected + hover brighten the base
+	// (selected less than hover); active blends towards a tint. All preserve the base opacity.
+	private static readonly ACTIVE_TINT = Cesium.Color.DEEPSKYBLUE;
+	private static readonly ACTIVE_TINT_AMOUNT = 0.8;
+	private static readonly SELECTED_BRIGHTEN = 0.5;
+	private static readonly HOVER_BRIGHTEN = 0.3;
+	// Base zone-boundary outline colour (does not change with selection/active state); its alpha
+	// tracks the zone layer's opacity slider.
+	private static readonly OUTLINE_COLOR = Cesium.Color.BLACK;
+
+	private readonly map: CesiumMap;
+	public readonly settings: ZonalStatisticsSettings;
+
+	/** Whether the tool is active and should react to map clicks. */
+	public readonly active: Writable<boolean> = writable(false);
+	/** Currently selected zones, in selection order. */
+	public readonly selectedZones: Writable<Array<SelectedZone>> = writable([]);
+
+	private zoneLayer: GeoJsonLayer | undefined;
+	/** Zone code -> zone-layer entities. A MultiPolygon zone becomes multiple entities (one per
+	 * part) that share the same code. Used to validate picks and compute area. */
+	private readonly zoneEntityIndex: Map<string, Array<Cesium.Entity>> = new Map();
+	/** Pickable entity -> its zone code, resolved once so picking/indexing skip getValue calls. */
+	private readonly entityCodeIndex: Map<Cesium.Entity, string> = new Map();
+	/** Resolved data layers per config id, in config order. */
+	private readonly dataLayers: Array<ResolvedDataLayer> = [];
+	/** Resolved data layers exposed to the zonal panel UI. */
+	public readonly resolvedDataLayers: Writable<Array<ResolvedDataLayer>> = writable([]);
+	/** True while `initialize()` is resolving/loading the configured layers. */
+	public readonly loading: Writable<boolean> = writable(false);
+	/** Per data-layer index: zone code -> feature properties (only the attributes the table reads). */
+	private readonly valueIndex: Map<string, Map<string, Record<string, any>>> = new Map();
+	/** Distinct data-layer attributes the table + tooltips read (column + tooltip attributes). */
+	private readonly neededAttributes: Array<string>;
+	/** Combined geodesic area per zone code, in square metres, computed on demand and cached. */
+	private readonly areaCache: Map<string, number> = new Map();
+
+	/** One batched fill primitive per unique layer id (zone + data layers), keyed by layer id. */
+	private readonly fillRenders: Map<string, FillLayerRender> = new Map();
+	/** Single batched primitive outlining every zone boundary (added on top of the fills). */
+	private zoneOutlinePrimitive: Cesium.Primitive | undefined;
+	/** Per-instance ids of the outline primitive, used to rescale their alpha with layer opacity. */
+	private readonly zoneOutlineIds: Array<object> = [];
+	/** Store/event unsubscribers for the fill primitives (visible/opacity/style/active). */
+	private readonly unsubscribers: Array<Unsubscriber> = [];
+	/** The zone currently shown in the table (drawn with the strongest tint). */
+	private activeCode: string | undefined;
+	/** The zone currently under the mouse (brightened), or undefined. */
+	private hoveredCode: string | undefined;
+	private clickHandler: ((l: MouseLocation) => void) | undefined;
+	private moveHandler: ((l: MouseLocation) => void) | undefined;
+
+	constructor(map: CesiumMap, settings: ZonalStatisticsSettings) {
+		this.map = map;
+		this.settings = settings;
+		const attrs = new Set<string>();
+		for (const column of settings.columns) {
+			attrs.add(column.attribute);
+			if (column.tooltipAttribute) attrs.add(column.tooltipAttribute);
+		}
+		this.neededAttributes = [...attrs];
+	}
+
+	/**
+	 * Resolve the configured layers, make sure their data is loaded (even while
+	 * hidden), index feature values by zone code, and start listening for clicks.
+	 */
+	public async initialize(): Promise<void> {
+		const zone = this.map.getLayerById(this.settings.zoneLayerId) as GeoJsonLayer | undefined;
+		if (!zone) {
+			console.warn(
+				`zonalStatistics: zone layer '${this.settings.zoneLayerId}' not found in map layers`
+			);
+			return;
+		}
+		this.loading.set(true);
+		try {
+			this.zoneLayer = zone;
+			await this.ensureLoaded(zone);
+			this.indexZoneEntities();
+
+			for (const cfg of this.settings.layers) {
+				const layer = this.map.getLayerById(cfg.id) as GeoJsonLayer | undefined;
+				if (!layer) {
+					console.warn(`zonalStatistics: data layer '${cfg.id}' not found in map layers`);
+					continue;
+				}
+				await this.ensureLoaded(layer);
+				this.dataLayers.push({
+					layerId: cfg.id,
+					title: cfg.title ?? layer.config.title,
+					layer
+				});
+				this.indexLayer(cfg.id, layer);
+			}
+			this.resolvedDataLayers.set([...this.dataLayers]);
+
+			this.buildFillRenders();
+			// Added after the fills so the boundary lines draw on top of them.
+			this.buildZoneOutlines();
+
+			this.clickHandler = (l: MouseLocation) => this.onMapClick(l);
+			this.map.on("mouseLeftClick", this.clickHandler as (n: unknown) => unknown);
+			this.moveHandler = (l: MouseLocation) => this.onMouseMove(l);
+			this.map.on("mouseMove", this.moveHandler as (n: unknown) => unknown);
+			this.unsubscribers.push(
+				this.active.subscribe((active) => {
+					if (!active) this.clearHover();
+				})
+			);
+		} finally {
+			this.loading.set(false);
+		}
+	}
+
+	/** Ensure a layer's data is loaded without toggling its visibility. */
+	private async ensureLoaded(layer: GeoJsonLayer): Promise<void> {
+		try {
+			await layer.ensureLoaded();
+		} catch (error) {
+			console.error(`zonalStatistics: failed to load layer '${layer.config.id}'`, error);
+		}
+	}
+
+	/**
+	 * Build one batched fill primitive per unique layer (zone + data layers): every polygon part
+	 * becomes a flat `PolygonGeometry` instance coloured with the layer's own label colour,
+	 * replacing the slow per-feature GeoJson entities. The entity fills are then hidden; the tool
+	 * renders + picks the primitives instead. No terrain is assumed, so the polygons sit flat at
+	 * height 0.
+	 */
+	private buildFillRenders(): void {
+		const uniqueLayers = new Map<string, GeoJsonLayer>();
+		if (this.zoneLayer) uniqueLayers.set(this.settings.zoneLayerId, this.zoneLayer);
+		for (const dl of this.dataLayers) uniqueLayers.set(dl.layerId, dl.layer);
+
+		for (const [layerId, layer] of uniqueLayers) {
+			const render = this.buildFillRender(layer);
+			if (!render) continue;
+			this.fillRenders.set(layerId, render);
+			this.hideEntityFills(layer);
+			this.unsubscribers.push(
+				layer.visible.subscribe((visible) => {
+					render.primitive.show = visible;
+					this.map.refresh();
+				}),
+				// The GeoJson layer updates its entity materials first on an opacity/style change, so
+				// re-reading here picks up the fresh colours before repainting the primitive.
+				layer.opacity.subscribe(() => this.refreshBaseColors(render)),
+				layer.style.subscribe(() => this.refreshBaseColors(render))
+			);
+		}
+	}
+
+	/** Build the batched fill primitive + id bookkeeping for one layer. */
+	private buildFillRender(layer: GeoJsonLayer): FillLayerRender | undefined {
+		const source = layer.source;
+		if (!source) return undefined;
+		const time = this.map.viewer.clock.currentTime;
+		const idsByCode = new Map<string, Array<ZoneInstanceId>>();
+		const entityById = new Map<ZoneInstanceId, Cesium.Entity>();
+		const baseColor = new Map<ZoneInstanceId, Cesium.Color>();
+		const instances: Array<Cesium.GeometryInstance> = [];
+
+		for (const entity of source.entities.values) {
+			const code = this.entityCodeIndex.get(entity);
+			if (code === undefined) continue;
+			const hierarchy = entity.polygon?.hierarchy?.getValue(time) as
+				| Cesium.PolygonHierarchy
+				| undefined;
+			if (!hierarchy || hierarchy.positions.length < 3) continue;
+			const color = this.readEntityColor(entity, time);
+			// Unique id object per part carrying the shared zone code (for picking + per-part recolour).
+			const id: ZoneInstanceId = { code };
+			instances.push(
+				new Cesium.GeometryInstance({
+					geometry: new Cesium.PolygonGeometry({
+						polygonHierarchy: hierarchy,
+						vertexFormat: Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
+						height: 0,
+						perPositionHeight: false
+					}),
+					attributes: { color: Cesium.ColorGeometryInstanceAttribute.fromColor(color) },
+					id
+				})
+			);
+			const list = idsByCode.get(code) ?? [];
+			list.push(id);
+			idsByCode.set(code, list);
+			entityById.set(id, entity);
+			baseColor.set(id, color);
+		}
+		if (instances.length === 0) return undefined;
+
+		const primitive = new Cesium.Primitive({
+			geometryInstances: instances,
+			appearance: new Cesium.PerInstanceColorAppearance({
+				translucent: true,
+				closed: false,
+				// Disable the depth test so the flat fills draw over the globe instead of clipping into it.
+				renderState: { depthTest: { enabled: false } }
+			}),
+			allowPicking: true,
+			asynchronous: true,
+			releaseGeometryInstances: false
+		});
+		primitive.show = get(layer.visible);
+		this.map.viewer.scene.primitives.add(primitive);
+		return { layer, primitive, idsByCode, entityById, baseColor };
+	}
+
+	/**
+	 * Outline every zone boundary as a single batched `Primitive` of `PolygonOutlineGeometry`
+	 * instances (one draw call, not thousands of entities), flat at height 0 with the depth test
+	 * off so the lines sit on top of the fills. Only the zone layer is outlined (data layers share
+	 * the same geometry); visibility follows the zone layer and the line alpha tracks its opacity.
+	 */
+	private buildZoneOutlines(): void {
+		const source = this.zoneLayer?.source;
+		if (!this.zoneLayer || !source) return;
+		const time = this.map.viewer.clock.currentTime;
+		const color = Cesium.ColorGeometryInstanceAttribute.fromColor(this.outlineColor());
+		const instances: Array<Cesium.GeometryInstance> = [];
+		this.zoneOutlineIds.length = 0;
+		for (const entity of source.entities.values) {
+			if (this.entityCodeIndex.get(entity) === undefined) continue;
+			const hierarchy = entity.polygon?.hierarchy?.getValue(time) as
+				| Cesium.PolygonHierarchy
+				| undefined;
+			if (!hierarchy || hierarchy.positions.length < 3) continue;
+			const id = {};
+			this.zoneOutlineIds.push(id);
+			instances.push(
+				new Cesium.GeometryInstance({
+					geometry: new Cesium.PolygonOutlineGeometry({
+						polygonHierarchy: hierarchy,
+						height: 0,
+						perPositionHeight: false
+					}),
+					attributes: { color },
+					id
+				})
+			);
+		}
+		if (instances.length === 0) return;
+		this.zoneOutlinePrimitive = new Cesium.Primitive({
+			geometryInstances: instances,
+			appearance: new Cesium.PerInstanceColorAppearance({
+				flat: true,
+				// Draw in the translucent pass (like the fills) so the outlines render *after* the
+				// semi-transparent fills instead of being painted over by them in a later pass. At
+				// equal (flat) depth Cesium's stable sort keeps this last-added primitive on top.
+				translucent: true,
+				renderState: { depthTest: { enabled: false } }
+			}),
+			allowPicking: false,
+			asynchronous: true,
+			releaseGeometryInstances: false
+		});
+		this.zoneOutlinePrimitive.show = get(this.zoneLayer.visible);
+		this.map.viewer.scene.primitives.add(this.zoneOutlinePrimitive);
+		this.unsubscribers.push(
+			this.zoneLayer.visible.subscribe((visible) => {
+				if (this.zoneOutlinePrimitive) this.zoneOutlinePrimitive.show = visible;
+				this.map.refresh();
+			}),
+			this.zoneLayer.opacity.subscribe(() => this.applyOutlineOpacity())
+		);
+	}
+
+	/** Outline colour with its alpha scaled to the zone layer's opacity slider (0…100 → 0…1). */
+	private outlineColor(): Cesium.Color {
+		const opacity = this.zoneLayer ? get(this.zoneLayer.opacity) : 100;
+		const alpha = Math.min(1, Math.max(0, opacity / 100));
+		return ZonalStatisticsController.OUTLINE_COLOR.withAlpha(alpha);
+	}
+
+	/** Rescale every outline instance's alpha to match the current zone-layer opacity. */
+	private applyOutlineOpacity(): void {
+		const primitive = this.zoneOutlinePrimitive;
+		if (!primitive || !primitive.ready) return;
+		const value = Cesium.ColorGeometryInstanceAttribute.toValue(this.outlineColor());
+		for (const id of this.zoneOutlineIds) {
+			const attributes = primitive.getGeometryInstanceAttributes(id);
+			if (attributes) attributes.color = value;
+		}
+		this.map.refresh();
+	}
+
+	/** Read a polygon entity's current fill colour (label colour + opacity) from its material. */
+	private readEntityColor(entity: Cesium.Entity, time: Cesium.JulianDate): Cesium.Color {
+		const material = entity.polygon?.material as Cesium.ColorMaterialProperty | undefined;
+		const color = material?.color?.getValue?.(time);
+		return color instanceof Cesium.Color ? color.clone() : Cesium.Color.GRAY.withAlpha(0.5);
+	}
+
+	/** Hide a layer's GeoJson entity polygon fills so only the batched primitive renders. */
+	private hideEntityFills(layer: GeoJsonLayer): void {
+		for (const entity of layer.source?.entities?.values ?? []) {
+			if (entity.polygon) entity.polygon.show = new Cesium.ConstantProperty(false);
+		}
+	}
+
+	/** Restore a layer's GeoJson entity polygon fills (undo `hideEntityFills`). */
+	private restoreEntityFills(layer: GeoJsonLayer): void {
+		for (const entity of layer.source?.entities?.values ?? []) {
+			if (entity.polygon) entity.polygon.show = new Cesium.ConstantProperty(true);
+		}
+	}
+
+	/** Re-read a layer's entity colours (after an opacity/style change) and repaint every part. */
+	private refreshBaseColors(render: FillLayerRender): void {
+		const time = this.map.viewer.clock.currentTime;
+		for (const [id, entity] of render.entityById) {
+			render.baseColor.set(id, this.readEntityColor(entity, time));
+		}
+		this.recolorRender(render);
+	}
+
+	/** Read a single entity property by name without materialising the whole property bag. */
+	private readProperty(entity: Cesium.Entity, attribute: string, time: Cesium.JulianDate): any {
+		const bag = entity.properties as unknown as
+			| Record<string, { getValue(t: Cesium.JulianDate): any } | undefined>
+			| undefined;
+		return bag?.[attribute]?.getValue(time);
+	}
+
+	/** Build a zone-code -> zone-layer entity lookup for resolving click geometry. */
+	private indexZoneEntities(): void {
+		this.zoneEntityIndex.clear();
+		const time = this.map.viewer.clock.currentTime;
+		const codeAttr = this.settings.zoneCodeAttribute;
+		const entities = this.zoneLayer?.source?.entities?.values ?? [];
+		for (const entity of entities) {
+			// Read only the code property instead of materialising every attribute per entity.
+			const code = this.readProperty(entity, codeAttr, time);
+			if (code !== undefined && code !== null) {
+				const key = String(code);
+				// A MultiPolygon zone becomes several entities under one code; keep them all.
+				const list = this.zoneEntityIndex.get(key) ?? [];
+				list.push(entity);
+				this.zoneEntityIndex.set(key, list);
+				this.entityCodeIndex.set(entity, key);
+			}
+		}
+	}
+
+	/** Build a zone-code -> properties lookup for one data layer. */
+	private indexLayer(layerId: string, layer: GeoJsonLayer): void {
+		const index = new Map<string, Record<string, any>>();
+		const time = this.map.viewer.clock.currentTime;
+		const codeAttr = this.settings.zoneCodeAttribute;
+		const entities = layer.source?.entities?.values ?? [];
+		for (const entity of entities) {
+			const code = this.readProperty(entity, codeAttr, time);
+			if (code === undefined || code === null) continue;
+			const key = String(code);
+			// Store only the attributes the table + tooltips read, not the whole property bag.
+			const props: Record<string, any> = {};
+			for (const attr of this.neededAttributes) props[attr] = this.readProperty(entity, attr, time);
+			index.set(key, props);
+			this.entityCodeIndex.set(entity, key);
+		}
+		this.valueIndex.set(layerId, index);
+	}
+
+	private onMapClick(location: MouseLocation): void {
+		if (!get(this.active)) return;
+		const code = this.pickZoneCode(location);
+		if (code !== undefined) this.toggleZone(code);
+	}
+
+	/** Hover handler: brighten the zone under the cursor, reverting the previously hovered one. */
+	private onMouseMove(location: MouseLocation): void {
+		if (!get(this.active)) return;
+		const code = this.pickZoneCode(location);
+		if (code === this.hoveredCode) return;
+		const previous = this.hoveredCode;
+		this.hoveredCode = code;
+		if (previous !== undefined) this.applyColor(previous);
+		if (code !== undefined) this.applyColor(code);
+		this.map.viewer.scene.canvas.style.cursor = code !== undefined ? "pointer" : "";
+	}
+
+	/** Resolve the zone code under a screen location from the picked fill-primitive instance id. */
+	private pickZoneCode(location: MouseLocation): string | undefined {
+		const picked = this.map.viewer.scene.pick(new Cesium.Cartesian2(location.x, location.y));
+		const id = Cesium.defined(picked) ? (picked.id as ZoneInstanceId | undefined) : undefined;
+		const code = id && typeof id === "object" && typeof id.code === "string" ? id.code : undefined;
+		return code !== undefined && this.zoneEntityIndex.has(code) ? code : undefined;
+	}
+
+	/** Fly the camera to frame the given zone, using the bounding sphere of all its polygon parts. */
+	public zoomToZone(code: string): void {
+		const time = this.map.viewer.clock.currentTime;
+		const positions: Array<Cesium.Cartesian3> = [];
+		for (const entity of this.zoneEntityIndex.get(code) ?? []) {
+			const hierarchy = entity.polygon?.hierarchy?.getValue(time) as
+				| Cesium.PolygonHierarchy
+				| undefined;
+			if (hierarchy?.positions) positions.push(...hierarchy.positions);
+		}
+		if (positions.length === 0) return;
+		const sphere = Cesium.BoundingSphere.fromPoints(positions);
+		// In 2D mode the camera must stay top-down; range 0 lets Cesium fit the sphere.
+		const pitch = get(this.map.options.use3DMode) ? -60 : -89.9;
+		this.map.viewer.camera.flyToBoundingSphere(sphere, {
+			duration: 1,
+			offset: new Cesium.HeadingPitchRange(0, Cesium.Math.toRadians(pitch), 0)
+		});
+	}
+
+	/** Add or remove a zone from the selection, then repaint it. */
+	public toggleZone(code: string): void {
+		const current = get(this.selectedZones);
+		if (current.some((z) => z.code === code)) {
+			this.selectedZones.set(current.filter((z) => z.code !== code));
+		} else {
+			this.selectedZones.set([...current, { code }]);
+		}
+		this.applyColor(code);
+	}
+
+	/**
+	 * Blend/brighten a zone's base label colour according to its current state
+	 * (active > selected > hover > base), preserving the base opacity so the label
+	 * hue stays visible in every state.
+	 */
+	private stateColor(code: string, base: Cesium.Color): Cesium.Color {
+		let result: Cesium.Color;
+		if (code === this.activeCode) {
+			result = Cesium.Color.lerp(
+				base,
+				ZonalStatisticsController.ACTIVE_TINT,
+				ZonalStatisticsController.ACTIVE_TINT_AMOUNT,
+				new Cesium.Color()
+			);
+		} else if (this.isSelected(code)) {
+			result = base.brighten(ZonalStatisticsController.SELECTED_BRIGHTEN, new Cesium.Color());
+		} else if (code === this.hoveredCode) {
+			result = base.brighten(ZonalStatisticsController.HOVER_BRIGHTEN, new Cesium.Color());
+		} else {
+			return base;
+		}
+		result.alpha = base.alpha;
+		return result;
+	}
+
+	/** Repaint one instance to match its zone's current state colour. */
+	private paintInstance(render: FillLayerRender, id: ZoneInstanceId): void {
+		const base = render.baseColor.get(id);
+		if (!base) return;
+		const attributes = render.primitive.getGeometryInstanceAttributes(id);
+		if (!attributes) return;
+		attributes.color = Cesium.ColorGeometryInstanceAttribute.toValue(
+			this.stateColor(id.code, base),
+			attributes.color
+		);
+	}
+
+	/** Repaint every part of one zone code across all fill primitives. */
+	private applyColor(code: string): void {
+		for (const render of this.fillRenders.values()) {
+			if (!render.primitive.ready) continue;
+			for (const id of render.idsByCode.get(code) ?? []) this.paintInstance(render, id);
+		}
+		this.map.refresh();
+	}
+
+	/** Repaint every part of one fill primitive (after its colours were refreshed). */
+	private recolorRender(render: FillLayerRender): void {
+		if (!render.primitive.ready) return;
+		for (const ids of render.idsByCode.values()) {
+			for (const id of ids) this.paintInstance(render, id);
+		}
+		this.map.refresh();
+	}
+
+	/** Clear the hover highlight (on mouse-out or tool deactivation). */
+	private clearHover(): void {
+		if (this.hoveredCode === undefined) return;
+		const previous = this.hoveredCode;
+		this.hoveredCode = undefined;
+		this.applyColor(previous);
+		this.map.viewer.scene.canvas.style.cursor = "";
+	}
+
+	/**
+	 * Mark the zone currently shown in the table so it gets the strongest tint while
+	 * the other selected zones keep the milder selection tint.
+	 */
+	public setActiveZone(code: string | undefined): void {
+		if (this.activeCode === code) return;
+		const previous = this.activeCode;
+		this.activeCode = code;
+		if (previous !== undefined) this.applyColor(previous);
+		if (code !== undefined) this.applyColor(code);
+	}
+
+	/** Remove all selected zones and repaint them back to their base colour. */
+	public clearSelection(): void {
+		const affected = new Set(get(this.selectedZones).map((z) => z.code));
+		if (this.activeCode !== undefined) affected.add(this.activeCode);
+		this.activeCode = undefined;
+		this.selectedZones.set([]);
+		for (const code of affected) this.applyColor(code);
+	}
+
+	/** Whether a zone with the given code is currently selected. */
+	public isSelected(code: string): boolean {
+		return get(this.selectedZones).some((z) => z.code === code);
+	}
+
+	/** Convert a property value into an optional string for table display. */
+	private toOptionalString(value: any): string | undefined {
+		return value !== undefined && value !== null ? String(value) : undefined;
+	}
+
+	/** Read an optional attribute from a props object as a string value. */
+	private readOptionalAttribute(
+		props: Record<string, any> | undefined,
+		attribute: string | undefined
+	): string | undefined {
+		if (!attribute) return undefined;
+		return this.toOptionalString(props?.[attribute]);
+	}
+
+	/** Build one table row for a resolved data layer across selected zones. */
+	private buildTableRow(dl: ResolvedDataLayer, zones: Array<string>): ZoneTableRow {
+		const index = this.valueIndex.get(dl.layerId);
+		const columns = this.settings.columns;
+		const values: Record<string, Array<string | undefined>> = {};
+		const tooltips: Record<string, Array<string | undefined>> = {};
+
+		for (const code of zones) {
+			const props = index?.get(code);
+			values[code] = columns.map((c) => this.toOptionalString(props?.[c.attribute]));
+			tooltips[code] = columns.map((c) => this.readOptionalAttribute(props, c.tooltipAttribute));
+		}
+
+		return {
+			layerId: dl.layerId,
+			title: dl.title,
+			values,
+			tooltips
+		};
+	}
+
+	/**
+	 * Build the per-column value + tooltip slice for a single zone across all
+	 * data layers (aligned to the resolved data-layer order). Used by the view
+	 * to update the table incrementally when one zone is (de)selected.
+	 */
+	public buildZoneSlice(
+		code: string
+	): Array<{ values: Array<string | undefined>; tooltips: Array<string | undefined> }> {
+		const columns = this.settings.columns;
+		return this.dataLayers.map((dl) => {
+			const props = this.valueIndex.get(dl.layerId)?.get(code);
+			return {
+				values: columns.map((c) => this.toOptionalString(props?.[c.attribute])),
+				tooltips: columns.map((c) => this.readOptionalAttribute(props, c.tooltipAttribute))
+			};
+		});
+	}
+
+	/**
+	 * Build the zone table for the current selection: one row per configured
+	 * data layer and one configured column per selected zone.
+	 */
+	public buildTable(): ZoneTable {
+		const zones = get(this.selectedZones).map((z) => z.code);
+		const rows: Array<ZoneTableRow> = this.dataLayers.map((dl) => this.buildTableRow(dl, zones));
+		return { zones, rows };
+	}
+
+	/** Parse a property value into a finite number (tolerating a comma decimal), or undefined. */
+	private toNumber(value: any): number | undefined {
+		if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+		if (typeof value === "string") {
+			const normalized = value.trim().replace(",", ".");
+			if (normalized === "") return undefined;
+			const parsed = Number(normalized);
+			return Number.isFinite(parsed) ? parsed : undefined;
+		}
+		return undefined;
+	}
+
+	/**
+	 * Convert a polygon ring's Cartesian3 positions to a closed lon/lat ring for
+	 * Turf, or undefined when it can't form a valid ring (< 4 closed positions).
+	 * Uses the raw hierarchy positions so the area matches the full-resolution
+	 * source geometry.
+	 */
+	private toClosedLonLatRing(
+		positions: Array<Cesium.Cartesian3> | undefined
+	): Array<[number, number]> | undefined {
+		if (!positions || positions.length < 3) return undefined;
+		const ring: Array<[number, number]> = positions.map((position) => {
+			const carto = Cesium.Cartographic.fromCartesian(position);
+			return [Cesium.Math.toDegrees(carto.longitude), Cesium.Math.toDegrees(carto.latitude)];
+		});
+		const first = ring[0];
+		const last = ring[ring.length - 1];
+		if (first[0] !== last[0] || first[1] !== last[1]) ring.push([first[0], first[1]]);
+		return ring.length >= 4 ? ring : undefined;
+	}
+
+	/**
+	 * Geodesic area of one polygon entity, in square metres, computed with Turf
+	 * from its full hierarchy (outer ring minus interior holes).
+	 */
+	private entityAreaSqMeters(entity: Cesium.Entity, time: Cesium.JulianDate): number {
+		const hierarchy = entity.polygon?.hierarchy?.getValue(time) as
+			| Cesium.PolygonHierarchy
+			| undefined;
+		const outer = this.toClosedLonLatRing(hierarchy?.positions);
+		if (!outer) return 0;
+		const rings: Array<Array<[number, number]>> = [outer];
+		for (const hole of hierarchy?.holes ?? []) {
+			const ring = this.toClosedLonLatRing(hole.positions);
+			if (ring) rings.push(ring);
+		}
+		return turf.area(turf.polygon(rings));
+	}
+
+	/** Combined area of a zone (summed over its polygon parts, holes subtracted), in m², cached per code. */
+	private zoneAreaSqMeters(code: string, time: Cesium.JulianDate): number {
+		const cached = this.areaCache.get(code);
+		if (cached !== undefined) return cached;
+		let area = 0;
+		for (const entity of this.zoneEntityIndex.get(code) ?? []) {
+			area += this.entityAreaSqMeters(entity, time);
+		}
+		this.areaCache.set(code, area);
+		return area;
+	}
+
+	/**
+	 * Build the computed summary for the current selection: total selected area
+	 * plus, per configured column, an area-per-category breakdown (styled columns)
+	 * or descriptive statistics (non-styled numeric columns). Recomputed on each
+	 * selection change (selections are few, areas are cached).
+	 */
+	public buildSummary(): ZonalSummary {
+		const codes = get(this.selectedZones).map((z) => z.code);
+		const time = this.map.viewer.clock.currentTime;
+
+		const areaByZone = new Map<string, number>();
+		let totalAreaSqMeters = 0;
+		for (const code of codes) {
+			const area = this.zoneAreaSqMeters(code, time);
+			areaByZone.set(code, area);
+			totalAreaSqMeters += area;
+		}
+
+		const columns = this.settings.columns;
+		const rows: Array<SummaryRow> = this.dataLayers.map((dl) => {
+			const index = this.valueIndex.get(dl.layerId);
+			const columnResults: Array<SummaryColumn> = columns.map((column, columnIndex) => {
+				if (column.styled) {
+					const areaByValue = new Map<string, number>();
+					for (const code of codes) {
+						const value = this.toOptionalString(index?.get(code)?.[column.attribute]);
+						if (value === undefined) continue;
+						areaByValue.set(value, (areaByValue.get(value) ?? 0) + (areaByZone.get(code) ?? 0));
+					}
+					const categories = [...areaByValue.entries()]
+						.map(([value, areaSqMeters]) => ({ value, areaSqMeters }))
+						.sort((a, b) => b.areaSqMeters - a.areaSqMeters);
+					return { columnIndex, styled: true, categories };
+				}
+
+				const numbers: Array<number> = [];
+				for (const code of codes) {
+					const parsed = this.toNumber(index?.get(code)?.[column.attribute]);
+					if (parsed !== undefined) numbers.push(parsed);
+				}
+				let numeric: NumericStat | undefined;
+				if (numbers.length > 0) {
+					const total = numbers.reduce((acc, n) => acc + n, 0);
+					numeric = {
+						min: Math.min(...numbers),
+						max: Math.max(...numbers),
+						mean: total / numbers.length,
+						count: numbers.length
+					};
+				}
+				return { columnIndex, styled: false, numeric };
+			});
+			return { layerId: dl.layerId, title: dl.title, columns: columnResults };
+		});
+
+		return { zoneCount: codes.length, totalAreaSqMeters, rows };
+	}
+
+	/**
+	 * Flatten the current zone table to export rows.
+	 * Export always reflects the currently visible table state.
+	 * Row order is zone-first so all entries for the same zone stay grouped.
+	 */
+	public buildExportRows(): Array<ZonalStatisticsExportRow> {
+		const table = this.buildTable();
+		const columnCount = this.settings.columns.length;
+		const exportRows: Array<ZonalStatisticsExportRow> = [];
+
+		for (const zone of table.zones) {
+			for (const row of table.rows) {
+				const values = row.values[zone] ?? [];
+				const tooltips = row.tooltips[zone] ?? [];
+				exportRows.push({
+					zoneCode: zone,
+					layerTitle: row.title,
+					values: Array.from({ length: columnCount }, (_, i) => values[i] ?? ""),
+					tooltips: Array.from({ length: columnCount }, (_, i) => tooltips[i] ?? "")
+				});
+			}
+		}
+
+		return exportRows;
+	}
+
+	/** Resolved data layers used by the zonal statistics left panel. */
+	public getResolvedDataLayers(): Array<ResolvedDataLayer> {
+		return get(this.resolvedDataLayers);
+	}
+
+	/** Detach listeners, remove the fill primitives, and restore the GeoJson entity fills. */
+	public destroy(): void {
+		if (this.clickHandler) {
+			this.map.off("mouseLeftClick", this.clickHandler as (n: unknown) => unknown);
+			this.clickHandler = undefined;
+		}
+		if (this.moveHandler) {
+			this.map.off("mouseMove", this.moveHandler as (n: unknown) => unknown);
+			this.moveHandler = undefined;
+		}
+		for (const unsubscribe of this.unsubscribers) unsubscribe();
+		this.unsubscribers.length = 0;
+		if (this.zoneOutlinePrimitive) {
+			this.map.viewer.scene.primitives.remove(this.zoneOutlinePrimitive);
+			this.zoneOutlinePrimitive = undefined;
+		}
+		this.zoneOutlineIds.length = 0;
+		for (const render of this.fillRenders.values()) {
+			this.map.viewer.scene.primitives.remove(render.primitive);
+			this.restoreEntityFills(render.layer);
+		}
+		this.fillRenders.clear();
+		this.map.viewer.scene.canvas.style.cursor = "";
+		this.map.refresh();
+	}
+}

--- a/src/lib/map-cesium/map-options.ts
+++ b/src/lib/map-cesium/map-options.ts
@@ -33,6 +33,7 @@ export class MapOptions {
 	public selectedProject: Writable<string | undefined> = writable(undefined);
 	public use3DMode: Writable<boolean> = writable(true);
 	public disableModeSwitcher: Writable<boolean> = writable(false);
+	public enableCollisionDetection: Writable<boolean> = writable<boolean>(false);
 
 	public pointCloudAttenuation: Writable<boolean> = writable<boolean>(true);
 	public pointCloudAttenuationMaximum: Writable<number> = writable<number>(0);
@@ -112,6 +113,9 @@ export class MapOptions {
 		this.subscribe<boolean>(this.inspector, (v) => {
 			this.switchTileInspector(v);
 		});
+		this.subscribe<boolean>(this.enableCollisionDetection, (v) => {
+			this.map.viewer.scene.screenSpaceCameraController.enableCollisionDetection = v;
+		});
 		this.subscribe<{ title: string, url: string, vertexNormals: boolean }>(this.selectedTerrainProvider, (v) => {
 			this.terrainSwitchReady.set(false);
 			this.switchTerrainProvider(v);
@@ -146,6 +150,7 @@ export class MapOptions {
 		this.trySet(this.pointCloudEDLRadius, config.pointCloudEDLRadius);
 		this.trySet(this.proMode, config.proMode);
 		this.trySet(this.globeOpacity, config.globeOpacity);
+		this.trySet(this.enableCollisionDetection, config.enableCollisionDetection);
 		this.loadTerrainProvider(config.terrainProviders);
 	}
 

--- a/src/lib/map-cesium/map.ts
+++ b/src/lib/map-cesium/map.ts
@@ -263,7 +263,7 @@ export class Map extends MapCore {
 		viewer.scene.postProcessStages.fxaa.enabled = get(this.options.fxaa);
 
 		// Enable going subsurface
-		viewer.scene.screenSpaceCameraController.enableCollisionDetection = false;
+		viewer.scene.screenSpaceCameraController.enableCollisionDetection = get(this.options.enableCollisionDetection);
 
 		// Set sun position
 		const date = new Date();

--- a/static/example.config.json
+++ b/static/example.config.json
@@ -278,6 +278,7 @@
                 "lighting": true,
                 "skyAtmosphere": true,
                 "fog": true,
+                "enableCollisionDetection": false,
                 "highDynamicRange": false,
                 "pointCloudAttenuationMaximum": 2,
                 "terrainProviders": [


### PR DESCRIPTION
**Merge ONLY after Dev>Main is done!**

- Replace story force2DMode with forceCameraMode ("2D"/"3D"), locking the camera while a story is open and restoring the prior mode on close
- Add per-layer showOpacitySlider option to story steps
- Add configurable enableCollisionDetection viewer setting
- Swap story back button icon (Exit -> Return)