### PR TITLE
Fix settings mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,15 +766,15 @@ Tool where the user can change settings of the Cesium viewer. Settings can be us
 |showMouseCoordinates|Debug window in viewer to show coordinates for mouse position|false|boolean|
 |showCameraPosition|Debug window to show the current camera position, updates on move|false|boolean|
 |showLoadingWidget|Show a small bar on the bottom of the viewer showing the loading progress of layers|false|boolean|
-|fxaa|FXAA enabled|false|Boolean|
-|msaa|MSAA samples|4|number|
+|fxaa|FXAA enabled|true|Boolean|
+|msaa|MSAA samples|1|number|
 |lighting|Enable lighting the globe with the scene's light source|true|boolean|
 |animate|Enable when displaying animated models else animations only update when the viewer refreshes it's view such as when panning/zooming|false|boolean|
 |resolutionScale|Gets or sets a scaling factor for rendering resolution. Values less than 1.0 can improve performance on less powerful devices while values greater than 1.0 will render at a higher resolution and then scale down, resulting in improved visual fidelity|window.devicePixelRatio|number|
-|maximumScreenSpaceError|The maximum screen space error used to drive level of detail refinement. for 3D tile layers|1.5|number|
+|maximumScreenSpaceError|The maximum screen space error used to drive level of detail refinement. for 3D tile layers|1.2|number|
 |groundAtmosphere|Ground atmosphere enabled|true|boolean|
 |fog|Fog enabled|true|boolean|
-|highDynamicRange|HDR enabled|true|boolean|
+|highDynamicRange|HDR enabled|false|boolean|
 |pointCloudAttenuation|3D Tile Point Cloud Attenuation enabled, Perform point attenuation based on geometric error|true|boolean|
 |pointCloudAttenuationMaximum|3D Tile Point Cloud Maximum point attenuation in pixels. If undefined, the Cesium3DTileset's maximumScreenSpaceError will be used|0|number|
 |pointCloudAttenuationErrorScale|Scale to be applied to the geometric error before computing attenuation|1|number|

--- a/src/lib/map-cesium/map-options.ts
+++ b/src/lib/map-cesium/map-options.ts
@@ -8,13 +8,13 @@ export class MapOptions {
 
 	public dateTime: Writable<number> = writable<number>(1720602000 * 1000); // 10-07-2024 11:00:00
 	public shadows: Writable<boolean> = writable<boolean>(false);
-	public fxaa: Writable<boolean> = writable<boolean>(false);
+	public fxaa: Writable<boolean> = writable<boolean>(true);
 	public animate: Writable<boolean> = writable<boolean>(false);
 	public resolutionScale: Writable<number> = writable<number>(1);
 	public maximumScreenSpaceError: Writable<number> = writable<number>(1.2);
 	public groundAtmosphere: Writable<boolean> = writable<boolean>(true);
 	public lighting: Writable<boolean> = writable<boolean>(true);
-	public msaa: Writable<number> = writable<number>(4);
+	public msaa: Writable<number> = writable<number>(1);
 	public skyAtmosphere: Writable<boolean> = writable<boolean>(true);
 	public fog: Writable<boolean> = writable<boolean>(true);
 	public highDynamicRange: Writable<boolean> = writable<boolean>(false);

--- a/src/lib/map-cesium/map.ts
+++ b/src/lib/map-cesium/map.ts
@@ -261,6 +261,7 @@ export class Map extends MapCore {
 
 		viewer.scene.highDynamicRange = get(this.options.highDynamicRange);
 		viewer.scene.postProcessStages.fxaa.enabled = get(this.options.fxaa);
+		viewer.scene.msaaSamples = get(this.options.msaa);
 
 		// Enable going subsurface
 		viewer.scene.screenSpaceCameraController.enableCollisionDetection = get(this.options.enableCollisionDetection);

--- a/static/example.config.json
+++ b/static/example.config.json
@@ -272,7 +272,7 @@
                 "shadows": false,
                 "animate": false,
                 "resolutionScale": 1,
-                "maximumScreenSpaceError": 16,
+                "maximumScreenSpaceError": 1.2,
                 "groundAtmosphere": true,
                 "globeOpacity": 100,
                 "lighting": true,


### PR DESCRIPTION
Settings should now default to 'medium'. Fixed default values when settings are missing in config. Also updated README so it matches the settings code